### PR TITLE
New keywords in evt2 file

### DIFF
--- a/marx/data/obs/acis_i_obs.par
+++ b/marx/data/obs/acis_i_obs.par
@@ -29,6 +29,10 @@ dither_z_amp,r,h,0.005556,,,"Dither Z amplitude"
 dither_z_freq,r,h,0.468400,,,"Dither Z frequency"
 dither_z_phase,r,h,0.000000,,,"Dither Z phase"
 #
+DY_AVG,r,h,0.00,,,"[mm] Mean DY during observation"
+DZ_AVG,r,h,0.00,,,"[mm] Mean DZ during observation"
+DTH_AVG,r,h,0.00,,,"[deg] Mean DTHETA during observation"
+#
 ascdsver,s,h,"R4CU3UPD24.3",,,"Processing system revision"
 dec_pnt,r,h,)dec_nom,,,"Pointing Dec"
 maneuver,s,h,"N",,,"Sky maneuver"

--- a/marx/data/obs/acis_s_obs.par
+++ b/marx/data/obs/acis_s_obs.par
@@ -29,6 +29,10 @@ dither_z_amp,r,h,0.005556,,,"Dither Z amplitude"
 dither_z_freq,r,h,0.468400,,,"Dither Z frequency"
 dither_z_phase,r,h,0.000000,,,"Dither Z phase"
 #
+DY_AVG,r,h,0.00,,,"[mm] Mean DY during observation"
+DZ_AVG,r,h,0.00,,,"[mm] Mean DZ during observation"
+DTH_AVG,r,h,0.00,,,"[deg] Mean DTHETA during observation"
+#
 ascdsver,s,h,"R4CU3UPD24.3",,,"Processing system revision"
 dec_pnt,r,h,)dec_nom,,,"Pointing Dec"
 maneuver,s,h,"N",,,"Sky maneuver"

--- a/marx/data/obs/hrc_i_obs.par
+++ b/marx/data/obs/hrc_i_obs.par
@@ -29,6 +29,10 @@ dither_z_amp,r,h,0.005556,,,"Dither Z amplitude"
 dither_z_freq,r,h,0.468400,,,"Dither Z frequency"
 dither_z_phase,r,h,0.000000,,,"Dither Z phase"
 #
+DY_AVG,r,h,0.00,,,"[mm] Mean DY during observation"
+DZ_AVG,r,h,0.00,,,"[mm] Mean DZ during observation"
+DTH_AVG,r,h,0.00,,,"[deg] Mean DTHETA during observation"
+#
 ascdsver,s,h,"R4CU3UPD24.3",,,"Processing system revision"
 dec_pnt,r,h,)dec_nom,,,"Pointing Dec"
 maneuver,s,h,"N",,,"Sky maneuver"

--- a/marx/data/obs/hrc_s_obs.par
+++ b/marx/data/obs/hrc_s_obs.par
@@ -29,6 +29,10 @@ dither_z_amp,r,h,0.005556,,,"Dither Z amplitude"
 dither_z_freq,r,h,0.468400,,,"Dither Z frequency"
 dither_z_phase,r,h,0.000000,,,"Dither Z phase"
 #
+DY_AVG,r,h,0.00,,,"[mm] Mean DY during observation"
+DZ_AVG,r,h,0.00,,,"[mm] Mean DZ during observation"
+DTH_AVG,r,h,0.00,,,"[deg] Mean DTHETA during observation"
+#
 ascdsver,s,h,"R4CU3UPD24.3",,,"Processing system revision"
 dec_pnt,r,h,)dec_nom,,,"Pointing Dec"
 maneuver,s,h,"N",,,"Sky maneuver"

--- a/marx/libsrc/caldb.c
+++ b/marx/libsrc/caldb.c
@@ -97,6 +97,12 @@ static int init_caldb (void)
    return 0;
 }
 
+/** Return the filename and path of a caldb data product from marxcaldb.par
+  * MARX includes a few CalDB files. The filename to be used is defined 
+  * in marxcaldb.par. This function looks for a key in that parameter file
+  * and returns the filename (e.g. _marx_caldb_get_file("GEOM")
+  * The return value includes the full, absolute path to the file.
+  */
 char *_marx_caldb_get_file (char *object)
 {
    Param_Table_Type *t;
@@ -125,6 +131,38 @@ char *_marx_caldb_get_file (char *object)
    marx_error ("Unable to find %s caldb file", object);
    return NULL;
 }
+
+/** Return the filename of a caldb data product from marxcaldb.par
+  * MARX includes a few CalDB files. The filename to be used is defined 
+  * in marxcaldb.par. This function looks for a key in that parameter file
+  * and returns the filename, e.g. marx_caldb_get_filename("GEOM") .
+  */
+char *marx_caldb_get_filename (char *object)
+{
+   Param_Table_Type *t;
+
+   if (-1 == init_caldb ())
+     return NULL;
+
+   t = Caldb_Parm_Table;
+   while (t->name != NULL)
+     {
+	char *file;
+
+	if (0 != strcmp (t->name, object))
+	  {
+	     t++;
+	     continue;
+	  }
+
+	file = *(char **) t->value;
+	return file;
+     }
+
+   marx_error ("Unable to find %s caldb file", object);
+   return NULL;
+}
+
 
 static int is_keyword_str (JDFits_Type *ft, char *key, char *val)
 {

--- a/marx/libsrc/marx.h
+++ b/marx/libsrc/marx.h
@@ -37,7 +37,7 @@
 
 /* These 6 quantities are used to specify the orientation of the optical
  * axis, as well as the detector offset and angle.  They are derived from
- * the aspect soloution.
+ * the aspect solution.
  */
 typedef struct
 {
@@ -291,6 +291,10 @@ extern int marx_create_photons (Marx_Source_Type *,
 				Marx_Photon_Type *,
 				unsigned int,
 				unsigned int *, double *);
+
+extern int marx_average_dither(double, double *, double *, double *);
+
+extern char *marx_caldb_get_filename (char *object);
 
 /*}}}*/
 

--- a/marx/src/marxasp.c
+++ b/marx/src/marxasp.c
@@ -114,8 +114,8 @@ static Param_File_Type *Obs_Par_Parms;
 typedef struct
 {
    unsigned int location;	       /* a bitmapped quantity */
-#define FULL_COMPONENT	1
-#define SHORT_COMPONENT	2
+#define FULL_COMPONENT 1
+#define SHORT_COMPONENT        2
 
    char *keyword;
    int type;
@@ -583,6 +583,9 @@ static int get_date (char *str)
    return 0;
 }
 
+
+/** Copy a single value h from a parameter file p to a fits file f.
+ */
 static int write_parfile_value (JDFits_Type *f, Param_File_Type *p,
 				Fits_Header_Table_Type *h)
 {
@@ -597,7 +600,7 @@ static int write_parfile_value (JDFits_Type *f, Param_File_Type *p,
    if ((p == NULL)
        || (-1 == (type = pf_get_type (p, name))))
      {
-	fprintf (stderr, "**Warning: %s not found obs.par file.\n", name);
+	fprintf (stderr, "**Warning: %s not found in obs.par file.\n", name);
 	return 0;
      }
 
@@ -637,6 +640,11 @@ static int write_parfile_value (JDFits_Type *f, Param_File_Type *p,
    return ret;
 }
 
+/** Write some keywords in h to fitsfile ft 
+ *  The mask integer selects which keywords are written.
+ *  It is combined with the location as the keywords as defined in h; only
+ *  keywords where location & mask are true will be written.
+ */
 static int write_extra_headers (JDFits_Type *ft,
 				Fits_Header_Table_Type *h,
 				unsigned int mask) /*{{{*/
@@ -796,6 +804,7 @@ static int add_goodtime_extension (JDFits_Type *ft)
    return jdfits_end_data (ft);
 }
 #endif
+
 static void compute_dither (double t, double *rap, double *decp, double *rollp,
 			    double *dyp, double *dzp, double *dthetap)
 {


### PR DESCRIPTION
Chandra repro-4 added new header keywords to evt2 files. Before, these parameters where read from the pbk and asol files, now access to these files is no longer required for some processing tools.
On the downside, these tools will now break with an error if the header keywords are not present (even though I am not convinced that they actually need them in some cases).
I noticed this in the scripts that make the grating responses (mkgarf, mktgresp, fullgarf).
MARX should add those keywords with reasonable value to the fits files it generates.

Here is more info on those changes, pulled from the CIAO docs:

For ACIS and HRC, three new keywords were added to capture the mean SIM offsets during an observation: DY_AVG, DZ_AVG, and DTH_AVG. These numbers are needed by tools like dmcoords, mkacisrmf, and mkwarf to correctly map detector coordinates back to the location on the instruments. Previously each tool used the information in the asolfile parameter to compute the mean value, every time the tool was run. With the mean values now simply encoded as header keywords, the tools can run more efficiently.

For ACIS, the information in the Level 0 parameter block file, pbk0, needed to compute the dead area calibration was also added to the event file headers. The new keywords include: SUM_2X2, FEP_CCD, ORCMODE, and OCLKPAIR. This information together with some existing keywords, is used by ARF and Exposure map tools when creating response. 

http://cxc.harvard.edu/ciao/watchout.html

http://cxc.harvard.edu/ciao/ahelp/r4_header_update.html