### PR TITLE
What happens if SpectrumFile constains no flux?

### DIFF
--- a/marx/libsrc/spectrum.c
+++ b/marx/libsrc/spectrum.c
@@ -74,6 +74,11 @@ static int compute_cumulated_vector (double *cum,
 	cum[i] = tot;
 	prev_x = this_x;
      }
+   if (tot == 0.0)
+     {
+       marx_error("Your file spectrum seems to have zero flux in it. MARX needs a positive integrated flux for a spectrum.");
+       return -1;
+     }
 
    if (total != NULL)
      {


### PR DESCRIPTION
A user reported over the email address that he  run marx with a file that contained only 0 in the flux column and still got photons in the output. I wonder how that happens. Maybe MARX should exit with an error in this case.