### PR TITLE
marx2fits crashes if file name of ASOLFILE is too long

### DIFF
--- a/marx/src/marx2fits.c
+++ b/marx/src/marx2fits.c
@@ -254,6 +254,7 @@ static int open_marx_chip_file (Data_Def_Type *);
 static int open_detxy (Data_Def_Type *);
 static int close_detxy (Data_Def_Type *);
 
+static int marx_fit_long_filename_in_fits (char *a);
 /*}}}*/
 
 #define MAX_BTABLE_COLUMNS 64
@@ -2329,6 +2330,20 @@ static int read_pileup_parms (void)
    return 0;
 }
 
+/** Shorten string so that it fits into the value field of a fits header
+ */
+static int marx_fit_long_filename_in_fits (char *a)
+{
+  char buf[67];
+  if (strlen(a) > 67)
+    {
+      strncpy(buf, a, 63);
+      strncat(buf, "...", 63);
+      strcpy(a, buf);
+    }
+  return 0;
+}
+
 #if 0
 static
 int _marx_strcasecmp (char *a, char *b)
@@ -2436,6 +2451,8 @@ static int get_marx_pfile_info (void) /*{{{*/
    else if (0 == strcmp(Dither_Model,"FILE"))
      {
        // Dither_File keeps the value in marx.par
+       // But if some user has Dither_File names too long to fit into fits:
+       marx_fit_long_filename_in_fits(Dither_File);
      }
    else
      {
@@ -2532,9 +2549,11 @@ static int get_marx_pfile_info (void) /*{{{*/
 
    if (NULL == (Geom_File = marx_caldb_get_filename ("GEOM")))
      return -1;
+   marx_fit_long_filename_in_fits(Geom_File);
 
    if (NULL == (Aimpts_File = marx_caldb_get_filename ("AIMPTS")))
      return -1;
+   marx_fit_long_filename_in_fits(Aimpts_File);
 
    return 0;
 }


### PR DESCRIPTION
From a user report:
  
I have a script that worked with marx 5.0, but that now fails with 5.1.
The script is (probably) dying at a stage where it is running marx2fits (the version 5.1.0-0 version on 64bit linux here), with the message:

ERROR: String is too long for keyword ASOLFILE
WARNING: Either the header or the data portion of the file was not ended.  I am assuming this is the data portion and filling it with 0.

It seems that I need to sanitize filenames that are longer than allowed for values in the fits header. In CIAO that does not happen, because the data reduction scripts produce filenames that are short enough automatically, but specifically for ASOLFILE users may input their own files.

I don't think there is an easy way to encode a value that is too long in the header, so I will probably do the following implementation:

- If the filename is too long, emit a warning.
- write the first few characters and append "..." to indicate that it's incomplete. (The fits standard says that he string can go up to column 80, but also that "reading the data values shall not require more than decoding the first 8 characters". I will use the limit that jdfits uses for this purpose. This is a rare case and fits is limited.)