### PR TITLE
do not specify __inline__

### DIFF
--- a/jdmath/src/dinterpo.c
+++ b/jdmath/src/dinterpo.c
@@ -27,9 +27,6 @@
 
 #include "jdmath.h"
 
-#if JDMATH_HAS_INLINE
-__inline__
-#endif
 unsigned int JDMbinary_search_d (double x, double *xp, unsigned int n)
 {
    unsigned int n0, n1, n2;

--- a/jdmath/src/jdmath.h
+++ b/jdmath/src/jdmath.h
@@ -129,9 +129,6 @@ extern int JDMcheck_types (unsigned long, unsigned long, unsigned long, unsigned
 #define JDMATH_CORRUPT_FILE_ERROR	7
 #define JDMATH_DIVIDE_ZERO_ERROR	8
 
-# define JDMATH_HAS_INLINE 0
-
-
 extern int JDMath_Error;
 extern int JDMUser_Break;
 
@@ -394,123 +391,6 @@ extern void JDMc_inc (JDMComplex_Type *, JDMComplex_Type);   /* *z += z1 */
 
 extern double JDMc_abs (JDMComplex_Type);     /* |z| */
 
-#if JDMATH_HAS_INLINE
-extern GNU_INLINE
-JDMComplex_Type JDMc_add (JDMComplex_Type z1, JDMComplex_Type z2)
-{
-   JDMComplex_Type z;
-   z.r = z1.r + z2.r;
-   z.i = z1.i + z2.i;
-   return z;
-}
-
-extern GNU_INLINE
-JDMComplex_Type JDMc_mul (JDMComplex_Type z1, JDMComplex_Type z2)
-{
-   JDMComplex_Type z;
-   z.r = z1.r * z2.r - z1.i * z2.i;
-   z.i = z1.r * z2.i + z1.i * z2.r;
-   return z;
-}
-
-extern GNU_INLINE
-JDMComplex_Type JDMc_sub (JDMComplex_Type z1, JDMComplex_Type z2)
-{
-   JDMComplex_Type z;
-   z.r = z1.r - z2.r;
-   z.i = z1.i - z2.i;
-   return z;
-}
-
-extern GNU_INLINE
-JDMComplex_Type JDMc_smul (double a, JDMComplex_Type z1)
-{
-   JDMComplex_Type z;
-   z.r = z1.r * a;
-   z.i = z1.i * a;
-   return z;
-}
-
-/* Multiple by imaginary scalar */
-extern GNU_INLINE
-JDMComplex_Type JDMc_imul (double a, JDMComplex_Type z1)
-{
-   JDMComplex_Type z;
-   z.r = -z1.i * a;
-   z.i = z1.r * a;
-   return z;
-}
-
-extern GNU_INLINE
-JDMComplex_Type JDMc_sadd (double a, JDMComplex_Type z1)
-{
-   JDMComplex_Type z;
-   z.r = z1.r + a;
-   z.i = z1.i;
-   return z;
-}
-
-extern GNU_INLINE
-JDMComplex_Type JDMComplex (double a, double b)
-{
-   JDMComplex_Type z;
-   z.r = a;
-   z.i = b;
-   return z;
-}
-
-extern GNU_INLINE
-JDMComplex_Type JDMc_a_bz (double a, double b, JDMComplex_Type z1)
-{
-   JDMComplex_Type z;
-   z.r = a + b * z1.r;
-   z.i = b * z1.i;
-   return z;
-}
-
-extern GNU_INLINE
-JDMComplex_Type JDMc_az1_bz2 (double a, JDMComplex_Type z1,
-			      double b, JDMComplex_Type z2)
-{
-   JDMComplex_Type z;
-   z.r = a * z1.r + b * z2.r;
-   z.i = a * z1.i + b * z2.i;
-   return z;
-}
-
-extern GNU_INLINE
-void JDMc_inc (JDMComplex_Type *z, JDMComplex_Type dz)
-{
-   z->r += dz.r;
-   z->i += dz.i;
-}
-
-extern GNU_INLINE
-int JDMc_eqs (JDMComplex_Type a, JDMComplex_Type b)
-{
-   return ((a.r == b.r) && (a.i == b.i));
-}
-
-extern GNU_INLINE
-int JDMc_neqs (JDMComplex_Type a, JDMComplex_Type b)
-{
-   return ((a.r != b.r) || (a.i != b.i));
-}
-
-extern GNU_INLINE
-double JDMc_real (JDMComplex_Type a)
-{
-   return a.r;
-}
-
-extern GNU_INLINE
-double JDMc_imag (JDMComplex_Type a)
-{
-   return a.i;
-}
-
-#endif				       /* JDMATH_HAS_INLINE */
-
 /* Vectors */
 typedef struct
 {
@@ -518,7 +398,6 @@ typedef struct
 }
 JDMVector_Type;
 
-/* Many of these can be inlined. */
 extern double JDMv_length (JDMVector_Type);
 extern JDMVector_Type JDMv_vector (double, double, double);
 extern JDMVector_Type JDMv_smul (double, JDMVector_Type);
@@ -544,136 +423,6 @@ extern double JDMv_find_rotation_axis (JDMVector_Type, JDMVector_Type, JDMVector
 extern void JDMv_spherical_to_triad (double theta, double phi,
 			      JDMVector_Type *r_hat, JDMVector_Type *theta_hat,
 			      JDMVector_Type *phi_hat);
-
-#if JDMATH_HAS_INLINE
-extern GNU_INLINE JDMVector_Type JDMv_vector (double x, double y, double z)
-{
-   JDMVector_Type v;  v.x = x; v.y = y; v.z = z; return v;
-}
-
-extern GNU_INLINE JDMVector_Type JDMv_smul (double t, JDMVector_Type v)
-{
-   v.x *= t; v.y *= t; v.z *= t; return v;
-}
-
-extern GNU_INLINE JDMVector_Type JDMv_cross_prod (JDMVector_Type a, JDMVector_Type b)
-{
-   JDMVector_Type c;
-   c.z = a.x * b.y - a.y * b.x;
-   c.x = a.y * b.z - a.z * b.y;
-   c.y = a.z * b.x - a.x * b.z;
-
-   return c;
-}
-
-extern GNU_INLINE JDMVector_Type JDMv_pcross_prod (JDMVector_Type *a, JDMVector_Type *b)
-{
-   JDMVector_Type c;
-   c.z = a->x * b->y - a->y * b->x;
-   c.x = a->y * b->z - a->z * b->y;
-   c.y = a->z * b->x - a->x * b->z;
-
-   return c;
-}
-
-extern GNU_INLINE JDMVector_Type JDMv_ax1_bx2 (double a, JDMVector_Type x1,
-					       double b, JDMVector_Type x2)
-{
-   JDMVector_Type c;
-
-   c.x = a * x1.x + b * x2.x;
-   c.y = a * x1.y + b * x2.y;
-   c.z = a * x1.z + b * x2.z;
-
-   return c;
-}
-
-extern GNU_INLINE JDMVector_Type JDMv_ax1_bx2_cx3 (double a, JDMVector_Type x1,
-						   double b, JDMVector_Type x2,
-						   double c, JDMVector_Type x3)
-{
-   JDMVector_Type d;
-
-   d.x = a * x1.x + b * x2.x + c * x3.x;
-   d.y = a * x1.y + b * x2.y + c * x3.y;
-   d.z = a * x1.z + b * x2.z + c * x3.z;
-
-   return d;
-}
-
-extern GNU_INLINE JDMVector_Type JDMv_pax1_bx2 (double a, JDMVector_Type *x1,
-						double b, JDMVector_Type *x2)
-{
-   JDMVector_Type c;
-
-   c.x = a * x1->x + b * x2->x;
-   c.y = a * x1->y + b * x2->y;
-   c.z = a * x1->z + b * x2->z;
-
-   return c;
-}
-
-extern GNU_INLINE double JDMv_dot_prod (JDMVector_Type a, JDMVector_Type b)
-{
-   return a.x * b.x + a.y * b.y + a.z * b.z;
-}
-
-extern GNU_INLINE double JDMv_pdot_prod (JDMVector_Type *a, JDMVector_Type *b)
-{
-   return a->x * b->x + a->y * b->y + a->z * b->z;
-}
-
-extern GNU_INLINE void JDMv_normalize (JDMVector_Type *a)
-{
-   double len;
-
-   if ((len = JDMv_length (*a)) != 0.0)
-     {
-	a->x = a->x / len;
-	a->y = a->y / len;
-	a->z = a->z / len;
-     }
-}
-
-extern GNU_INLINE JDMVector_Type JDMv_unit_vector (JDMVector_Type a)
-{
-   JDMv_normalize (&a);
-   return a;
-}
-
-extern GNU_INLINE JDMVector_Type JDMv_sum (JDMVector_Type x1, JDMVector_Type x2)
-{
-   JDMVector_Type c;
-
-   c.x = x1.x + x2.x;
-   c.y = x1.y + x2.y;
-   c.z = x1.z + x2.z;
-
-   return c;
-}
-
-extern GNU_INLINE JDMVector_Type JDMv_diff (JDMVector_Type x1, JDMVector_Type x2)
-{
-   JDMVector_Type c;
-
-   c.x = x1.x - x2.x;
-   c.y = x1.y - x2.y;
-   c.z = x1.z - x2.z;
-
-   return c;
-}
-
-extern GNU_INLINE double JDMv_distance (JDMVector_Type a, JDMVector_Type b)
-{
-   a.x -= b.x;
-   a.y -= b.y;
-   a.z -= b.z;
-
-   return JDMv_length (a);
-}
-#endif
-
-typedef double JDM_3Matrix_Type [3][3];
 
 /* These define ACTIVE rotations of the coordinate system.  */
 extern void JDM3m_rot_x_matrix (JDM_3Matrix_Type, double);

--- a/jdmath/src/jdmath.h
+++ b/jdmath/src/jdmath.h
@@ -129,25 +129,8 @@ extern int JDMcheck_types (unsigned long, unsigned long, unsigned long, unsigned
 #define JDMATH_CORRUPT_FILE_ERROR	7
 #define JDMATH_DIVIDE_ZERO_ERROR	8
 
-/* clang defines GNUC, but used c99 sematics for extern inline.  This implementation
- * assume GNU semantics.
- * Unfortunately, older versoin of gcc don't define __GNUC_GNU_INLINE__
- * so we need to take care of that first.
- */
-#if defined __GNUC__ && !defined __GNUC_STDC_INLINE__ && !defined __GNUC_GNU_INLINE__ && !defined __clang__
-# define __GNUC_GNU_INLINE__ 1
-#endif
-#if __GNUC_GNU_INLINE__
-# define JDMATH_HAS_INLINE 1
-# define GNU_INLINE __inline__
-#else
-# if !defined __GNUC_STDC_INLINE__
-#  define JDMATH_HAS_INLINE 0      /* non-gcc compilers */
-# else                       /* modern gcc with __GNUC_GNU_INLINE__ false */
-#  define JDMATH_HAS_INLINE 1
-#  define GNU_INLINE __inline__ __attribute__((gnu_inline))
-# endif
-#endif
+# define JDMATH_HAS_INLINE 0
+
 
 extern int JDMath_Error;
 extern int JDMUser_Break;

--- a/jdmath/src/jdmath.h
+++ b/jdmath/src/jdmath.h
@@ -18,7 +18,7 @@
 #ifndef JDMATH_H_INCLUDED
 #define JDMATH_H_INCLUDED
 
-#define JDMATH_VERSION 182	       /* 1.82 */
+#define JDMATH_VERSION 183	       /* 1.83 */
 #include <stdio.h>
 #include <math.h>
 


### PR DESCRIPTION
I've run extensive speeds tests with different compilers on different machine.
I did not test marx2fits, because it generally makes up only a small fraction of the marx runtime (specifically for large simulations where the the runtime matters most) and I did not test marxasp (again, it usually makes up small fraction of the runtime, except for very long observations with very low cont rates).

I tested on
- CentOS 6.6 with gcc 4.4 and 4.8 and clang 3.3 (64 GB RAM, 12 core processor)
- Macbook Air with clang 7.0.0 in apple versioning
- Ubuntu 14.04 with gcc 4.8 and clang 4.3 (0.7 GB RAM)

I found that the runtime does not differ by more than 10% (usually it's within 5%) between this commit (no inline) and the master (inline specified for gcc). In most cases, it is actually faster **not** to request inlineing manually - and this is true for all optimization levels above `O0`.

It seems that the overhead saved by inlining is smaller than other optimizations that modern compilers can do when the program does not specify any specific optimization through function attributes.