### PR TITLE
set pointing offset to 0

### DIFF
--- a/marx/par/marx.par
+++ b/marx/par/marx.par
@@ -218,8 +218,8 @@ HRMA_P6H6_XOffset,r,h,-0.541755,,,"HRMA P6H6 X offset (mm)"
 #
 #    adjusted to agree with flight data
 #
-PointingOffsetY,r,h,-21,,,"Optical-Axis/Pointing Y Misalignment (arcsec)"
-PointingOffsetZ,r,h,12,,,"Optical-Axis/Pointing Z Misalignment (arcsec)"
+PointingOffsetY,r,h,0,,,"Optical-Axis/Pointing Y Misalignment (arcsec)"
+PointingOffsetZ,r,h,0,,,"Optical-Axis/Pointing Z Misalignment (arcsec)"
 #----------------------------------------------------------------------------
 #
 # EA Mirror Setup


### PR DESCRIPTION
Below is the (shortened) version of an email exchange on marx-help

For observed files RA_PNT & DEC_PNT, in the event files, is the mean-pointing of the HRMA. We usually pick this to be location of the tangent point so RA_NOM = RA_PNT and DEC_NOM = DEC_PNT (ROLL_NOM = ROLL_PNT too, but not critical here).

The marx2fits outputs (in v5.0 and 5.1) has different values for the (RA|DEC)_NOM and the (RA|DEC)_PNT keywords.

Hi Kenny,

RA_NOM and DEC_NOM are indeed just the user input values that are
carried over to the fits file output.
As you found out by experimenting RA_PNT and DEC_PNT are calculated from
RA_NOM and DEC_NOM with the PointingOffsetY|Z and the roll angle.

PointingOffsetY|Z set "the misaligment between the HRMA optical axis and
the nominal pointing".
Unfortunately, that means that I don't know exactly why the given
default values were chosen. It is possible that the represent an offset
between aspect camera and HRMA, but if so I cannot find the the source
of those numbers.

PointingOffsetY/Z is not used at any position in the code except to
calculate the RA_PNT and DEC_PNT for the output. If you have no
misalignment between the optical axis and the pointing direction, you
can set them to 0 with no side effects.

Today, there is no offset between the optical axis and nominal pointing in observed Chandra data.

closes #10