### PR TITLE
MARX PSF wrong for off-axis sources

### DIFF
--- a/marx/libsrc/hrma.c
+++ b/marx/libsrc/hrma.c
@@ -705,9 +705,8 @@ static int init_hrma_shells (Param_File_Type *pf) /*{{{*/
 	 * of the conic.  Assume that the maximum off-axis angle of interest
 	 * is 40'.  Use: dr/length=tan(theta)
 	 */
-#if 0
 	h->min_radius -= h->length_p * tan (0.67 * PI/180);
-#endif
+
 	if (h->num_open_shutters)
 	  {
 	     total_area += (h->num_open_shutters / 4.0) *


### PR DESCRIPTION
Comparing an observation of a bright, off-axis source (ObsID 1068), I discovered a major problem in the simulated PSF in MARX.

![marxbug](https://cloud.githubusercontent.com/assets/498688/12952420/676b41dc-cfe4-11e5-8767-8cd21540dc56.png)

Only MARX has that obvious big hole in the lower part op the PSF. 
The image shows the Chandra observation, a MARX only simulation and a SAOTrace ray-trace with MARX as the instrument model. The fact that this shows up only in MARX indicates that something is wrong with the MARX mirror.

Further investigation shows that this affects only off-axis sources (the source in the image is 25 arcmin off-axis) and only using the MARX HRMA mirror module.