### PR TITLE
Change defaults in marx.par for HRC PSF

### DIFF
--- a/marx/par/marx.par
+++ b/marx/par/marx.par
@@ -438,6 +438,10 @@ ACIS-I3-FilterFile,f,h,"acis/acis_i_xray_trans_1198.dat",,,"ACIS Chip 3 OBF file
 #---------------------------------------------------------------------------
 # The blur parameters were extracted from
 #   <http://cxc.harvard.edu/twiki/bin/view/HrcCal/DetectorPSF>.
+# However, comparison to observations in Dec 2018 shows that the PSFs
+# with these characteristics are too wide in the wings. 
+# Thus, we return to a Gaussian distribution shown to fit better while
+# this issue is investigated in more detail.
 # The (Xctr,Yctr) are offset at runtime such that (G1Xctr,G1Yctr)=(0,0).
 #
 HRC-I-BlurG1FWHM,r,h,13.8994,0,,"HRC-I Gauss1 FWHM (1/4 pixels)"
@@ -447,11 +451,11 @@ HRC-I-BlurG1Amp,r,h,15.7528,0,,"HRC-I Gauss1 Amp"
 HRC-I-BlurG2FWHM,r,h,4.25636,0,,"HRC-I Gauss2 FWHM (1/4 pixels)"
 HRC-I-BlurG2Xctr,r,h,61.35,0,,"HRC-I Gauss2 Xctr (1/4 pixels)"
 HRC-I-BlurG2Yctr,r,h,64.178,0,,"HRC-I Gauss2 Yctr (1/4 pixels)"
-HRC-I-BlurG2Amp,r,h,5.19162,0,,"HRC-I Gauss2 Amp"
+HRC-I-BlurG2Amp,r,h,0.0,0,,"HRC-I Gauss2 Amp"
 HRC-I-BlurL1FWHM,r,h,10.8269,0,,"HRC-I Lorentz1 FWHM (1/4 pixels)"
 HRC-I-BlurL1Xctr,r,h,73.3361,0,,"HRC-I Lorentz1 Xctr (1/4 pixels)"
 HRC-I-BlurL1Yctr,r,h,63.9927,0,,"HRC-I Lorentz1 Yctr (1/4 pixels)"
-HRC-I-BlurL1Amp,r,h,0.978579,0,,"HRC-I Lorentz1 Amp"
+HRC-I-BlurL1Amp,r,h,0.0,0,,"HRC-I Lorentz1 Amp"
 HRC-I-BlurL1Rmax,r,h,256,0,,"HRC-I Lorentz1 Rmax (1/4 pixels)"
 #
 HRC-I-QEFile,f,h,"hrc/mcp_qe_i.v2.2.dat",,,"HRC-I QE File"
@@ -468,11 +472,11 @@ HRC-S-BlurG1Amp,r,h,15.750,0,,"HRC-S Gauss1 Amp"
 HRC-S-BlurG2FWHM,r,h,4.2560,0,,"HRC-S Gauss2 FWHM (1/4 pixels)"
 HRC-S-BlurG2Xctr,r,h,67.420,0,,"HRC-S Gauss2 Xctr (1/4 pixels)"
 HRC-S-BlurG2Yctr,r,h,64.110,0,,"HRC-S Gauss2 Yctr (1/4 pixels)"
-HRC-S-BlurG2Amp,r,h,5.1920,0,,"HRC-S Gauss2 Amp"
+HRC-S-BlurG2Amp,r,h,0.0,0,,"HRC-S Gauss2 Amp"
 HRC-S-BlurL1FWHM,r,h,10.820,0,,"HRC-S Lorentz1 FWHM (1/4 pixels)"
 HRC-S-BlurL1Xctr,r,h,53.030,0,,"HRC-S Lorentz1 Xctr (1/4 pixels)"
 HRC-S-BlurL1Yctr,r,h,63.880,0,,"HRC-S Lorentz1 Yctr (1/4 pixels)"
-HRC-S-BlurL1Amp,r,h,0.9790,0,,"HRC-S Lorentz1 Amp"
+HRC-S-BlurL1Amp,r,h,0.0,0,,"HRC-S Lorentz1 Amp"
 HRC-S-BlurL1Rmax,r,h,256.000,0,,"HRC-S Lorentz1 Rmax (1/4 pixels)"
 #
 HRC-S-QEFile0,f,h,"hrc/mcp_qe_s.v3.dat",,,"HRC QE File for MCP 0"


### PR DESCRIPTION
An email from Vinay Kashyap summarizes the reason for this change:
We discovered a problem with how HRC raytraces of point sources are
handled.  See attached figure (figure removed because data is not public)
 of radial surface brightness
profiles of data from a suspected point source vs different methods of
raytraces.  Green is bare HRMA, sans detector; blue is data; black is
current default ChaRT+MARX; and red is ChaRT+MARX with different HRC-I
blur parameters (see below).  The curves are normalized to a peak of
1.

As you can see, the default raytrace predicts a significantly larger
wing than is observed.  We believe we have tracked this down to a
difference in how MARX renormalizes the amplitude of the 2D Lorentzian
compared to the Sherpa model function.

MARX uses a 2 Gaussian + 1 Lorentzian function to model the HRC
detector blur.  Diab tested cases where he manually set the amplitudes
of the second Gaussian and the Lorentzian to zero, and gets a
reasonably good match to the data --
HRC-I-BlurG1FWHM=12.44
HRC-I-BlurG2Amp=0
HRC-I-BlurL1Amp=0
The same changes would also apply to HRC-S-*.