### PR TITLE
Change data type of PI and PHA columns written to match CIAO

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -1,3 +1,9 @@
+Marx 6.0 (unreleased)
+=====================
+
+Change column type of PHA and PI columns written by ``marx2fits`` to float32
+to match the files that CIAO writes.
+
 Marx 5.4 (Dec 2018)
 ===================
 Update `CalDB`_ files that are shipped with |marx| to `CalDB`_ version 4.8.2.

--- a/marx/src/marx2fits.c
+++ b/marx/src/marx2fits.c
@@ -684,12 +684,12 @@ static Data_Def_Type Data_Def_Table [] = /*{{{*/
 #endif
       "PHA",			       /* colname */
       "Total PHA for event",	       /* comment */
-      "I",			       /* type */
+      "J",			       /* type */
       "adu",			       /* units */
       NULL,			       /* WCS CTYPE */
       13,			       /* column_number */
       read_int16_to_int32,	       /* compute_value */
-      write_int32_as_int16,		       /* write_value */
+      write_int32,		       /* write_value */
       open_marx_int16_file,	       /* open */
       close_marx_file,		       /* close */
       NULL,			       /* cdt */
@@ -1178,18 +1178,18 @@ static Data_Def_Type Data_Def_Table [] = /*{{{*/
    },
 #endif
    {
-      'I',			       /* type */
+      'J',			       /* type */
       &Data_Table.dtt_pi,	       /* pointer to value */
       NULL,			       /* filename */
       DDT_NEED_ACIS,		       /* flags */
       "PI",			       /* colname */
       "pulse invariant energy of event",/* comment */
-      "I",			       /* type */
+      "J",			       /* type */
       "Chan",			       /* units */
       NULL,			       /* WCS CTYPE */
       15,			       /* column_number */
       compute_pi,		       /* compute_value */
-      write_int16,		       /* write_value */
+      write_int16_as_int32,		       /* write_value */
       NULL,			       /* open */
       NULL,			       /* close */
       NULL,			       /* cdt */


### PR DESCRIPTION
This is required to dmmerge marx2fits output to e.g. ACIS stowed background files.
The exampel I used ot test this earlier used he background file
acis7sD2009-09-21bkgrndN0001.fits
where the N0001 in the file name is a version number. That older version uses the
 >i2 type and I had made marx to match that. In the current CALDB, there is a newer version of this file
acis7sD2009-09-21bkgrndN0002.fits
which is version N0002, which uses >i4 data datatype for PHA and PI columns.
My scripts did not catch that change, because I had the filename of the datafile hardcoded.
This commit switches marx2fits to use >i4 to match the event files (and background files)
that the current version of CIAO produces.