### PR TITLE
Assign energy before calling user_create_ray

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -4,6 +4,18 @@ Marx 6.0 (unreleased)
 Change column type of PHA and PI columns written by ``marx2fits`` to float32
 to match the files that CIAO writes.
 
+User-compiled sources (``SourceType="USER"``) have a function called
+``user_create_ray`` which is called with a pointer to ray properties
+(direction, time, and energy). All ray properties used to be undefined before
+calling this function and the user function could return ``-1`` for energy and
+time to have |marx| assign energy and time. Now, ``energy`` is initialized
+*before* ``user_create_ray`` is called, to allow user code that assigns
+locations based on the ray energy.  With this change, marx.par must contain a
+valid specification for the source spectrum, since an energy will be drawn,
+even if the user source later assigns a different value. For
+backwards-compatibility, if ``user_create_ray`` sets the energy to a negative
+value, |marx| will assign the energy drawn before to the variable again.
+
 Marx 5.4 (Dec 2018)
 ===================
 Update `CalDB`_ files that are shipped with |marx| to `CalDB`_ version 4.8.2.
@@ -16,8 +28,7 @@ parameters used in previous versions of |marx| are determined. However, we
 recently found that the PSFs are wider than observed. Thus, in this version we
 change the values of the default `marx.par` file to use a single Gaussian
 instead. This change is most important for the profile of the wings in very
-bright HRC sources.  We continue to investigate this and expect another change
-in the next |marx| release.
+bright HRC sources.  We continue to investigate this and expect another change soon.
 
 
 Marx 5.3.3 (Dec 2017)

--- a/marx/doc/examples/user-source/grayscale.c
+++ b/marx/doc/examples/user-source/grayscale.c
@@ -75,7 +75,6 @@ int user_create_ray (double *delta_t, double *energy,
    double x, y, tmp;
 
    *delta_t = -1.0;
-   *energy = -1.0;
    
    r = JDMrandom ();
    n = JDMbinary_search_f (r, Image, (512 * 512));

--- a/marx/doc/examples/user-source/grid.c
+++ b/marx/doc/examples/user-source/grid.c
@@ -38,7 +38,6 @@ int user_create_ray (double *delta_t, double *energy,
    *cosz = sin_theta * sin (phi);
 
    *delta_t = -1.0;
-   *energy = -1.0;
    
    last_i++;  
 

--- a/marx/doc/examples/user-source/image.c
+++ b/marx/doc/examples/user-source/image.c
@@ -195,7 +195,6 @@ int user_create_ray (double *delta_t, double *energy,
    double x, y, tmp;
 
    *delta_t = -1.0;
-   *energy = -1.0;
    
    r = JDMrandom ();
    n = JDMbinary_search_f (r, Image, Image_Size);

--- a/marx/doc/examples/user-source/off-axis.c
+++ b/marx/doc/examples/user-source/off-axis.c
@@ -28,7 +28,6 @@ int user_create_ray (double *delta_t, double *energy,
    *cosz = Source_CosZ;
 
    *delta_t = -1.0;
-   *energy = -1.0;
    return 0;
 }
 

--- a/marx/doc/examples/user-source/point.c
+++ b/marx/doc/examples/user-source/point.c
@@ -28,7 +28,6 @@ int user_create_ray (double *delta_t, double *energy,
    *cosz = Source_CosZ;
 
    *delta_t = -1.0;
-   *energy = -1.0;
    
    return 0;
 }

--- a/marx/libsrc/s-user.c
+++ b/marx/libsrc/s-user.c
@@ -164,7 +164,7 @@ static int create_photons (Marx_Source_Type *st, Marx_Photon_Type *pt, /*{{{*/
    unsigned int i;
    Marx_Photon_Attr_Type *at;
    int (*efun) (Marx_Spectrum_Type *, double *);
-   double t, energy, last_time;
+   double t, energy, energy_drawn, last_time;
 
    if (User_Start_Iteration != NULL)
      {
@@ -185,6 +185,11 @@ static int create_photons (Marx_Source_Type *st, Marx_Photon_Type *pt, /*{{{*/
      {
 	double p1, p2, p3;
 
+	if (-1 == (*efun) (&st->spectrum, &energy_drawn))
+	  return -1;
+	
+	energy = energy_drawn;
+
 	if (-1 == (*User_Generate_Ray) (&t, &energy, &p1, &p2, &p3))
 	  break;
 
@@ -200,10 +205,15 @@ static int create_photons (Marx_Source_Type *st, Marx_Photon_Type *pt, /*{{{*/
 	     at->arrival_time = last_time;
 	  }
 
+	/* This will not be called, unless the User_Generate_Ray resets the
+           energy, but for backwards compatibility, we need it:
+           Up to marx 5.4 the energy before user_generate_ray
+           was undefined and the user source was expected to set it to
+           -1, if it wanted marx to draw as usual.
+	*/
 	if (energy < 0.0)
 	  {
-	     if (-1 == (*efun) (&st->spectrum, &energy))
-	       return -1;
+	    energy = energy_drawn;
 	  }
 
 	at->energy = energy;


### PR DESCRIPTION
User-compiled sources (``SourceType="USER"``) have a function called
``user_create_ray`` which is called with a pointer to ray properties
(direction, time, and energy). All ray properties used to be undefined before
calling this function and the user function could return ``-1`` for energy and
time to have |marx| assign energy and time. Now, ``energy`` is initialized
*before* ``user_create_ray`` is called, to allow user code that assigns
locations based on the ray energy.  With this change, marx.par must contain a
valid specification for the source spectrum, since an energy will be drawn,
even if the user source later assigns a different value. For
backwards-compatibility, if ``user_create_ray`` sets the energy to a negative
value, |marx| will assign the energy drawn before to the variable again.

closes #38