### PR TITLE
s-image.c: fix offsets when inputting an image.

### DIFF
--- a/marx/libsrc/s-image.c
+++ b/marx/libsrc/s-image.c
@@ -327,16 +327,26 @@ static int image_create_photons (Marx_Source_Type *st, Marx_Photon_Type *pt, /*{
 	if (-1 == (*efun) (&st->spectrum, &at->energy))
 	  return -1;
 
-	ofs = JDMbinary_search_f (JDMrandom (), Image, Image_Size);
-
-	y = (double) (ofs / X_Image_Size);
+	// binary_search is finding the last pixel less than JDMrandom().
+	// We want the 1st pixel that includes JDMrandom(), so +1.
+	ofs = JDMbinary_search_f (JDMrandom (), Image, Image_Size) +1;
+	if (ofs >= Image_Size) {
+	    ofs = Image_Size-1;
+	}
+	
+	y = (double) floor(ofs / X_Image_Size);  // floor() because we want the integer part only here
 	x = (double) (ofs % X_Image_Size);
+
+	/* Convert from C-array index to image pixel index */
+	y += 1;
+	x += 1;
 
 	/* Center the image and randomize within the pixel.  Note that the
 	 * average of the RHS of next expression is 0.5*YSize
 	 */
-	y -= 0.5 * (Y_Image_Size - 1) + JDMrandom ();
-	x -= 0.5 * (X_Image_Size - 1) + JDMrandom ();
+
+	y -= 0.5 * Y_Image_Size + JDMrandom ();
+	x -= 0.5 * X_Image_Size + JDMrandom ();
 
 	y = y * Rad_Per_YPixel;
 	x = x * Rad_Per_XPixel;


### PR DESCRIPTION
This is for #50 

There are a couple of fixes here

- The `binary_search` routine is finding the last pixel below the random   value.  However, what is needed is the 1st pixel that includes (>=)   the random value.  This is causing a 1 pixel shift in X (or a missed   wrap if at the edge of the image).
- We want to use `floor(x/len)` when computing the X coordinate.   Even though this is integer divided by integer, it's still producing   a floating point value -- but we don't want the fractional part   of division.  This will also cause a fractional shift in the X coordinate.

The other `+1` changes are there to help clarify the change from C-index (0:n-1) to pixel index (1:n).

This looks to fix the case in #50, though it's easier to see when working with an image with odd axis lengths

```bash
dmcopy delta.img"[bin #1=1:101:1,#2=1:101:1]" delta101.img
pset marx_delta S-ImageFile=delta101.img
```

Will definitely need to be run through marx's test suite.


