### PR TITLE
Fix bug in jdmath binary search algorithm

### DIFF
--- a/jdmath/src/finterpo.c
+++ b/jdmath/src/finterpo.c
@@ -47,6 +47,8 @@ unsigned int JDMbinary_search_f (float x, float *xp, unsigned int n)
 	     n0 = n2;
 	  }
      }
+
+   if (x >= xp[n0]) return n1;
    return n0;
 }
 

--- a/marx/libsrc/s-image.c
+++ b/marx/libsrc/s-image.c
@@ -332,13 +332,15 @@ static int image_create_photons (Marx_Source_Type *st, Marx_Photon_Type *pt, /*{
 	y = (double) (ofs / X_Image_Size);
 	x = (double) (ofs % X_Image_Size);
 
-	/* Center the image and randomize within the pixel.  Note that the
-	 * average of the RHS of next expression is 0.5*YSize
+	/* Center the image and randomize within the pixel.
+   * In fits, the image center is at an integer pixel, so we need to
+   * subtract 0.5 to make the random number from -0.5 to 0.5 so
+   * the distribution is centered on the pixel.
 	 */
-	y -= 0.5 * (Y_Image_Size - 1) + JDMrandom ();
-	x -= 0.5 * (X_Image_Size - 1) + JDMrandom ();
+  y += -0.5 * Y_Image_Size + (JDMrandom () - 0.5);
+	x += -0.5 * X_Image_Size + (JDMrandom () - 0.5);
 
-	y = y * Rad_Per_YPixel;
+  y = y * Rad_Per_YPixel;
 	x = x * Rad_Per_XPixel;
 
 	cos_y = cos (y);

--- a/marx/libsrc/s-image.c
+++ b/marx/libsrc/s-image.c
@@ -73,66 +73,66 @@ static int read_image (JDFits_Type *ft, int bitpix, unsigned int n1, unsigned in
    switch (bitpix)
      {
       case -32:			       /* float32 */
-	for (i = 0; i < Image_Size; i++)
-	  {
-	     float32 f32;
-	     if (1 != jdfits_read_float32 (ft, &f32, 1))
-	       goto read_error;
-	     Image [i] = (float) f32;
-	  }
-	break;
+  for (i = 0; i < Image_Size; i++)
+    {
+       float32 f32;
+       if (1 != jdfits_read_float32 (ft, &f32, 1))
+         goto read_error;
+       Image [i] = (float) f32;
+    }
+  break;
 
       case -64:			       /* double */
-	for (i = 0; i < Image_Size; i++)
-	  {
-	     float64 f64;
-	     if (1 != jdfits_read_float64 (ft, &f64, 1))
-	       goto read_error;
-	     Image [i] = (float) f64;
-	  }
-	break;
+  for (i = 0; i < Image_Size; i++)
+    {
+       float64 f64;
+       if (1 != jdfits_read_float64 (ft, &f64, 1))
+         goto read_error;
+       Image [i] = (float) f64;
+    }
+  break;
 
       case 8:
-	if (NULL == (read_buf = (unsigned char *) marx_malloc (X_Image_Size)))
-	  goto return_error;
-	for (i = 0; i < Y_Image_Size; i++)
-	  {
-	     unsigned int j;
-	     float *im;
+  if (NULL == (read_buf = (unsigned char *) marx_malloc (X_Image_Size)))
+    goto return_error;
+  for (i = 0; i < Y_Image_Size; i++)
+    {
+       unsigned int j;
+       float *im;
 
-	     if (X_Image_Size != jdfits_read_bytes (ft, read_buf, X_Image_Size))
-	       goto read_error;
+       if (X_Image_Size != jdfits_read_bytes (ft, read_buf, X_Image_Size))
+         goto read_error;
 
-	     im = Image + i * X_Image_Size;
-	     for (j = 0; j < X_Image_Size; j++)
-	       im [j] = (float) read_buf[j];
-	  }
-	marx_free ((char *)read_buf);
-	read_buf = NULL;
-	break;
+       im = Image + i * X_Image_Size;
+       for (j = 0; j < X_Image_Size; j++)
+         im [j] = (float) read_buf[j];
+    }
+  marx_free ((char *)read_buf);
+  read_buf = NULL;
+  break;
 
       case 16:
-	for (i = 0; i < Image_Size; i++)
-	  {
-	     int16 i16;
-	     if (1 != jdfits_read_int16 (ft, &i16, 1))
-	       goto read_error;
-	     Image [i] = (float) i16;
-	  }
-	break;
+  for (i = 0; i < Image_Size; i++)
+    {
+       int16 i16;
+       if (1 != jdfits_read_int16 (ft, &i16, 1))
+         goto read_error;
+       Image [i] = (float) i16;
+    }
+  break;
 
       case 32:
-	for (i = 0; i < Image_Size; i++)
-	  {
-	     int32 i32;
-	     if (1 != jdfits_read_int32 (ft, &i32, 1))
-	       goto read_error;
-	     Image [i] = (float) i32;
-	  }
-	break;
+  for (i = 0; i < Image_Size; i++)
+    {
+       int32 i32;
+       if (1 != jdfits_read_int32 (ft, &i32, 1))
+         goto read_error;
+       Image [i] = (float) i32;
+    }
+  break;
       default:
-	marx_error ("BITPIX = %d is not supported", bitpix);
-	goto return_error;
+  marx_error ("BITPIX = %d is not supported", bitpix);
+  goto return_error;
      }
 
    /* compute a cumulative distribution */
@@ -164,9 +164,9 @@ static int read_keyword_int (JDFits_Type *ft, char *kw, int *i, int is_error)
 
    if (NULL == (k = jdfits_find_keyword (ft, kw)))
      {
-	if (is_error)
-	  marx_error ("Error locating keyword %s", kw);
-	return -1;
+  if (is_error)
+    marx_error ("Error locating keyword %s", kw);
+  return -1;
      }
 
    if (0 == jdfits_extract_integer (k, i))
@@ -184,9 +184,9 @@ static int read_keyword_double (JDFits_Type *ft, char *kw, double *d, int is_err
 
    if (NULL == (k = jdfits_find_keyword (ft, kw)))
      {
-	if (is_error)
-	  marx_error ("Error locating keyword %s", kw);
-	return -1;
+  if (is_error)
+    marx_error ("Error locating keyword %s", kw);
+  return -1;
      }
 
    if (0 == jdfits_extract_double (k, d))
@@ -208,51 +208,51 @@ static int open_image_fits_file (char *file)
    marx_message ("Opening IMAGE fits file %s\n", file);
    if (NULL == (ft = jdfits_open_file (file, JDFITS_READ_MODE)))
      {
-	marx_error ("Failed to open %s", file);
-	return -1;
+  marx_error ("Failed to open %s", file);
+  return -1;
      }
 
    if ((-1 == read_keyword_int (ft, "NAXIS1", &naxis1, 1))
        || (-1 == read_keyword_int (ft, "NAXIS2", &naxis2, 1))
        || (-1 == read_keyword_int (ft, "BITPIX", &bitpix, 1)))
      {
-	jdfits_close_file (ft);
-	return -1;
+  jdfits_close_file (ft);
+  return -1;
      }
 
    /* Look for scale factors */
    if (0 == read_keyword_double (ft, "CDELT1", &scale1, 0))
      {
-	if (-1 == read_keyword_double (ft, "CDELT2", &scale2, 1))
-	  {
-	     jdfits_close_file (ft);
-	     return -1;
-	  }
-	scale1 = fabs (scale1);
-	scale2 = fabs (scale2);
+  if (-1 == read_keyword_double (ft, "CDELT2", &scale2, 1))
+    {
+       jdfits_close_file (ft);
+       return -1;
+    }
+  scale1 = fabs (scale1);
+  scale2 = fabs (scale2);
      }
    else if (0 == read_keyword_double (ft, "CD1_1", &scale1, 0))
      {
-	double cd1_1, cd1_2, cd2_1, cd2_2;
+  double cd1_1, cd1_2, cd2_1, cd2_2;
 
-	cd1_1 = scale1;
+  cd1_1 = scale1;
 
-	if ((-1 == read_keyword_double (ft, "CD1_2", &cd1_2, 1))
-	    || (-1 == read_keyword_double (ft, "CD2_1", &cd2_1, 1))
-	    || (-1 == read_keyword_double (ft, "CD2_2", &cd2_2, 1)))
-	  {
-	     jdfits_close_file (ft);
-	     return -1;
-	  }
-	scale1 = sqrt (cd1_1 * cd1_1 + cd1_2 * cd1_2);
-	scale2 = sqrt (cd2_1 * cd2_1 + cd2_2 * cd2_2);
+  if ((-1 == read_keyword_double (ft, "CD1_2", &cd1_2, 1))
+      || (-1 == read_keyword_double (ft, "CD2_1", &cd2_1, 1))
+      || (-1 == read_keyword_double (ft, "CD2_2", &cd2_2, 1)))
+    {
+       jdfits_close_file (ft);
+       return -1;
+    }
+  scale1 = sqrt (cd1_1 * cd1_1 + cd1_2 * cd1_2);
+  scale2 = sqrt (cd2_1 * cd2_1 + cd2_2 * cd2_2);
      }
    else scale1 = scale2 = 0.0;
 
    if ((scale1 == 0.0) || (scale2 == 0.0))
      {
-	marx_error ("Cannot determine scale of image.  Assuming 0.5 arc-sec per pixel");
-	scale1 = scale2 = 0.5 / 3600.0;
+  marx_error ("Cannot determine scale of image.  Assuming 0.5 arc-sec per pixel");
+  scale1 = scale2 = 0.5 / 3600.0;
      }
 
    Rad_Per_XPixel = scale1 * PI / 180.0;
@@ -260,8 +260,8 @@ static int open_image_fits_file (char *file)
 
    if (-1 == read_image (ft, bitpix, (unsigned int) naxis1, (unsigned int) naxis2))
      {
-	jdfits_close_file (ft);
-	return -1;
+  jdfits_close_file (ft);
+  return -1;
      }
 
    jdfits_close_file (ft);
@@ -285,7 +285,7 @@ static int image_close_source (Marx_Source_Type *st) /*{{{*/
 /*}}}*/
 
 static int image_create_photons (Marx_Source_Type *st, Marx_Photon_Type *pt, /*{{{*/
-				 unsigned int num, unsigned int *num_created)
+         unsigned int num, unsigned int *num_created)
 {
    unsigned int i;
    Marx_Photon_Attr_Type *at;
@@ -306,8 +306,8 @@ static int image_create_photons (Marx_Source_Type *st, Marx_Photon_Type *pt, /*{
    /* handle roundoff-error */
    if (fabs (theta) > 1.0)
      {
-	if (theta < 0) theta = -1.0;
-	else theta = 1.0;
+  if (theta < 0) theta = -1.0;
+  else theta = 1.0;
      }
    theta = acos (theta);
 
@@ -320,42 +320,42 @@ static int image_create_photons (Marx_Source_Type *st, Marx_Photon_Type *pt, /*{
 
    for (i = 0; i < num; i++)
      {
-	unsigned int ofs;
-	double x, y, cos_y;
-	JDMVector_Type p1;
+  unsigned int ofs;
+  double x, y, cos_y;
+  JDMVector_Type p1;
 
-	if (-1 == (*efun) (&st->spectrum, &at->energy))
-	  return -1;
+  if (-1 == (*efun) (&st->spectrum, &at->energy))
+    return -1;
 
-	ofs = JDMbinary_search_f (JDMrandom (), Image, Image_Size);
+  ofs = JDMbinary_search_f (JDMrandom (), Image, Image_Size);
 
-	y = (double) (ofs / X_Image_Size);
-	x = (double) (ofs % X_Image_Size);
+  y = (double) (ofs / X_Image_Size);
+  x = (double) (ofs % X_Image_Size);
 
-	/* Center the image and randomize within the pixel.
+  /* Center the image and randomize within the pixel.
    * In fits, the image center is at an integer pixel, so we need to
    * subtract 0.5 to make the random number from -0.5 to 0.5 so
    * the distribution is centered on the pixel.
-	 */
+   */
   y += -0.5 * Y_Image_Size + (JDMrandom () - 0.5);
-	x += -0.5 * X_Image_Size + (JDMrandom () - 0.5);
+  x += -0.5 * X_Image_Size + (JDMrandom () - 0.5);
 
   y = y * Rad_Per_YPixel;
-	x = x * Rad_Per_XPixel;
+  x = x * Rad_Per_XPixel;
 
-	cos_y = cos (y);
+  cos_y = cos (y);
 
-	/* Note that an image on the sky has +X running in -Marx_Y, and
-	 * +Y in +Marx_Z.  So, when flipping the vector to point to the
-	 * origin, take these into account.
-	 */
-	p1.x = -cos_y * cos (x);
-	p1.y = cos_y * sin (x);	       /* <-- no flip here */
-	p1.z = -sin (y);
+  /* Note that an image on the sky has +X running in -Marx_Y, and
+   * +Y in +Marx_Z.  So, when flipping the vector to point to the
+   * origin, take these into account.
+   */
+  p1.x = -cos_y * cos (x);
+  p1.y = cos_y * sin (x);	       /* <-- no flip here */
+  p1.z = -sin (y);
 
-	at->p = JDMv_rotate_unit_vector (p1, normal, theta);
+  at->p = JDMv_rotate_unit_vector (p1, normal, theta);
 
-	at++;
+  at++;
      }
 
    *num_created = num;
@@ -365,7 +365,7 @@ static int image_create_photons (Marx_Source_Type *st, Marx_Photon_Type *pt, /*{
 /*}}}*/
 
 int marx_select_image_source (Marx_Source_Type *st, Param_File_Type *p, /*{{{*/
-			      char *name, unsigned int source_id)
+            char *name, unsigned int source_id)
 {
    char buf [PF_MAX_LINE_LEN];
 


### PR DESCRIPTION
Once an interval was narrowed down to just two elements, the binary search algorithm always returned the lower of the two. That's not correct.

This bug was found by simulations of a one-pixel source that happens to be off by one pixel. If, in that example, the source would have been located at +1 or -1 pixel compared to the test that was run, this bug would have gone unnoticed.

Changes in "s-image.c" are mostly cosmetic to make it easier to reason why the formula works,
by removing the double negative. I *think* there was als oa 0.5 pixel offset before, but since it's hard to reason about, I opted for simplifying and making sure it's correct by testing a simulation.

fixes #50
closes #54