### PR TITLE
Add warning if simulation ends because it reaches the end of the ASPSOL file

### DIFF
--- a/marx/libsrc/_marx.h
+++ b/marx/libsrc/_marx.h
@@ -88,7 +88,7 @@ typedef struct
 }
 _Marx_HRC_QE_Type;
 
-extern int _marx_hrc_read_efficiencies (_Marx_HRC_QE_Type *);
+extern int _marx_hrc_read_efficiencies (_Marx_HRC_QE_Type *, int);
 extern int _marx_hrc_s_geom_init (Param_File_Type *);
 extern int _marx_hrc_i_geom_init (Param_File_Type *);
 extern int _marx_hrc_i_get_pixel_size (double *dx, double *dy);
@@ -103,7 +103,7 @@ extern short _marx_hrc_compute_pha (double);
 
 extern int _marx_acis_apply_qe_and_pha (_Marx_Acis_Chip_Type *, Marx_Photon_Attr_Type *);
 extern void _marx_free_acis_chip_type (_Marx_Acis_Chip_Type *);
-extern int _marx_acis_read_chip_efficiencies (_Marx_Acis_Chip_Type *);
+extern int _marx_acis_read_chip_efficiencies (_Marx_Acis_Chip_Type *, int);
 #if !MARX_HAS_ACIS_GAIN_MAP && !MARX_HAS_ACIS_FEF
 extern short _marx_acis_compute_fs_pha (_Marx_Acis_Chip_Type *, float, float, double, float *);
 extern short _marx_acis_compute_bs_pha (_Marx_Acis_Chip_Type *, float, float, double, float *);
@@ -118,7 +118,7 @@ extern int _marx_apply_acis_rmf (_Marx_Acis_Chip_Type *c, float x, float y,
 
 extern void _marx_acis_apply_streak (double, Marx_Photon_Attr_Type *, Marx_Detector_Geometry_Type *);
 extern int _marx_acis_get_generic_parms (Param_File_Type *);
-extern int _marx_acis_contam_init (Param_File_Type *, _Marx_Acis_Chip_Type *);
+extern int _marx_acis_contam_init (Param_File_Type *, _Marx_Acis_Chip_Type *, int);
 
 extern int _Marx_Det_Ideal_Flag;
 extern int _marx_set_detector_angle (double);
@@ -164,9 +164,9 @@ extern int _marx_hrc_i_detect (Marx_Photon_Type *);
 extern int _marx_acis_s_detect (Marx_Photon_Type *);
 extern int _marx_acis_i_detect (Marx_Photon_Type *);
 extern int _marx_hrc_s_init (Param_File_Type *);
-extern int _marx_hrc_i_init (Param_File_Type *);
-extern int _marx_acis_s_init (Param_File_Type *);
-extern int _marx_acis_i_init (Param_File_Type *);
+extern int _marx_hrc_i_init(Param_File_Type *);
+extern int _marx_acis_s_init(Param_File_Type *);
+extern int _marx_acis_i_init(Param_File_Type *);
 
 #if MARX_HAS_IXO_SUPPORT
 extern int _marx_ixoccd_init (Param_File_Type *);
@@ -214,7 +214,7 @@ extern char *_marx_caldb_get_file (char *object);
 extern int _marx_caldb_patch_acis_geom (Marx_Detector_Type *d);
 extern int _marx_caldb_patch_aimpoint (Marx_Detector_Type *d);
 extern int _marx_caldb_patch_hrc_s_geom (Marx_Detector_Type *d);
-extern int _marx_read_acis_qe (int ccdid, float **enp, float **qep, unsigned int *np);
+extern int _marx_read_acis_qe (int ccdid, float **enp, float **qep, unsigned int *np, int);
 extern JDFits_Type *_marx_open_binary_hdu (char *file, char *hduname);
 
 typedef struct
@@ -243,13 +243,13 @@ extern int _marx_compute_detector_basis (Marx_Detector_Type *);
 extern Marx_Detector_Geometry_Type *_marx_find_detector_facet (Marx_Detector_Type *, int);
 extern Marx_Detector_Geometry_Type *_marx_link_detector_facet_list (Marx_Detector_Geometry_Type *, unsigned int, unsigned int);
 
-extern Marx_Detector_Type *_marx_get_acis_s_detector (void);
-extern Marx_Detector_Type *_marx_get_acis_i_detector (void);
-extern Marx_Detector_Type *_marx_get_hrc_s_detector (void);
-extern Marx_Detector_Type *_marx_get_hrc_i_detector (void);
+extern Marx_Detector_Type *_marx_get_acis_s_detector (int);
+extern Marx_Detector_Type *_marx_get_acis_i_detector (int);
+extern Marx_Detector_Type *_marx_get_hrc_s_detector (int);
+extern Marx_Detector_Type *_marx_get_hrc_i_detector (int);
 #if MARX_HAS_IXO_SUPPORT
-extern Marx_Detector_Type *_marx_get_ixo_ccd_detector (void);
-extern Marx_Detector_Type *_marx_get_ixo_xms_detector (void);
+extern Marx_Detector_Type *_marx_get_ixo_ccd_detector (int);
+extern Marx_Detector_Type *_marx_get_ixo_xms_detector (int);
 #endif
 
 typedef struct _Marx_QE_Type Marx_QE_Type;

--- a/marx/libsrc/acis-i.c
+++ b/marx/libsrc/acis-i.c
@@ -38,6 +38,8 @@
 #include "marx.h"
 #include "_marx.h"
 
+static int verbose = 0;
+
 /* This structure is used for the QE curves */
 typedef struct
 {
@@ -301,6 +303,9 @@ int _marx_acis_i_init (Param_File_Type *p) /*{{{*/
    Marx_Detector_Type *acis_i;
    unsigned int i;
 
+   if (-1 == pf_get_integer(p, "Verbose", &verbose))
+     return -1;
+
 #if MARX_HAS_ACIS_FEF
    if (-1 == marx_init_acis_i_rmf (p))
      return -1;
@@ -312,7 +317,7 @@ int _marx_acis_i_init (Param_File_Type *p) /*{{{*/
    if (-1 == get_acis_parms (p))
      return -1;
 
-   if (NULL == (acis_i = marx_get_detector_info ("ACIS-I")))
+   if (NULL == (acis_i = marx_get_detector_info ("ACIS-I", verbose)))
      return -1;
 
    ACIS_I_Chips = acis_i->facet_list;
@@ -323,7 +328,7 @@ int _marx_acis_i_init (Param_File_Type *p) /*{{{*/
 #endif
 
    if (_Marx_Det_Ideal_Flag == 0)
-     marx_message ("Reading ACIS-I QE/Filter Files\n");
+     if (verbose > 0) marx_message ("Reading ACIS-I QE/Filter Files\n");
 
    for (i = 0; i < _MARX_NUM_ACIS_I_CHIPS; i++)
      {
@@ -339,9 +344,9 @@ int _marx_acis_i_init (Param_File_Type *p) /*{{{*/
 #endif
 	if (_Marx_Det_Ideal_Flag == 0)
 	  {
-	     if (-1 == _marx_acis_read_chip_efficiencies (ccd))
+	     if (-1 == _marx_acis_read_chip_efficiencies (ccd, verbose))
 	       return -1;
-	     if (-1 == _marx_acis_contam_init (p, ccd))
+	     if (-1 == _marx_acis_contam_init (p, ccd, verbose))
 	       return -1;
 	  }
      }

--- a/marx/libsrc/acis_fef.c
+++ b/marx/libsrc/acis_fef.c
@@ -82,6 +82,8 @@
 
 #define FIRST_CHAN 1
 
+static int verbose = 0;
+
 typedef struct
 {
    float amp;
@@ -881,8 +883,11 @@ static int read_acis_fef (Param_File_Type *p, int min_ccdid, int max_ccdid)
    if (file == NULL)
      return -1;
 
-   marx_message ("Reading ACIS-I/S FEF File\n");
-   marx_message ("\t%s\n", file);
+   if (-1 == pf_get_integer(p, "Verbose", &verbose))
+     return -1;
+
+   if (verbose > 0) marx_message("Reading ACIS-I/S FEF File\n");
+   if (verbose > 1) marx_message("\t%s\n", file);
    status = read_fef_file (file, min_ccdid, max_ccdid);
    marx_free (file);
    return status;

--- a/marx/libsrc/acis_gain.c
+++ b/marx/libsrc/acis_gain.c
@@ -436,7 +436,7 @@ static int read_gain_map (char *file, int min_ccdid, int max_ccdid)
    return -1;
 }
 
-static int read_acis_gain_map (Param_File_Type *p, int min_ccdid, int max_ccdid)
+static int read_acis_gain_map (Param_File_Type *p, int min_ccdid, int max_ccdid, int verbose)
 {
    char buf [PF_MAX_LINE_LEN];
    char *file;
@@ -452,8 +452,8 @@ static int read_acis_gain_map (Param_File_Type *p, int min_ccdid, int max_ccdid)
    if (file == NULL)
      return -1;
 
-   marx_message ("Reading ACIS-I/S Gain File\n");
-   marx_message ("\t%s\n", file);
+   (if verbose > 0) marx_message ("Reading ACIS-I/S Gain File\n");
+   (if verbose > 1) marx_message ("\t%s\n", file);
    status = read_gain_map (file, min_ccdid, max_ccdid);
    marx_free (file);
    return status;

--- a/marx/libsrc/acis_geom.c
+++ b/marx/libsrc/acis_geom.c
@@ -142,7 +142,7 @@ acis_i_to_tiled (Marx_Detector_Type *det,
    return 0;
 }
 
-Marx_Detector_Type *_marx_get_acis_i_detector (void)
+Marx_Detector_Type *_marx_get_acis_i_detector (int verbose)
 {
    Marx_Detector_Type *d;
    Marx_Detector_Geometry_Type *g;
@@ -201,7 +201,7 @@ static int acis_s_to_tiled (Marx_Detector_Type *det,
    return 0;
 }
 
-Marx_Detector_Type *_marx_get_acis_s_detector (void)
+Marx_Detector_Type *_marx_get_acis_s_detector (int verbose)
 {
    int ccd_id;
    Marx_Detector_Type *d;

--- a/marx/libsrc/aciscontam.c
+++ b/marx/libsrc/aciscontam.c
@@ -317,7 +317,7 @@ static int find_binary_table_callback (void *cd, JDFits_Type *ft)
 }
 
 
-static int read_contam_file_for_ccd (char *file, int ccd)
+static int read_contam_file_for_ccd (char *file, int ccd, int verbose)
 {
    JDFits_Type *f;
    JDFits_Row_Type *r;
@@ -330,8 +330,8 @@ static int read_contam_file_for_ccd (char *file, int ccd)
 
    contam = Single_Component_Contam_Table+ccd;
 
-   marx_message ("Reading ACIS%d Contamination File\n", ccd);
-   marx_message ("\t%s\n", file);
+   if (verbose > 0) marx_message ("Reading ACIS%d Contamination File\n", ccd);
+   if (verbose > 1) marx_message ("\t%s\n", file);
 
    if (NULL == (f = jdfits_find_binary_table (file, find_binary_table_callback, (void *)&ccd)))
      {
@@ -492,7 +492,7 @@ return_error_bad_row:
    return -1;
 }
 
-int _marx_acis_contam_init (Param_File_Type *p, _Marx_Acis_Chip_Type *ccd)
+int _marx_acis_contam_init (Param_File_Type *p, _Marx_Acis_Chip_Type *ccd, int verbose)
 {
    char *file;
 
@@ -501,7 +501,7 @@ int _marx_acis_contam_init (Param_File_Type *p, _Marx_Acis_Chip_Type *ccd)
    if (NULL == (file = _marx_caldb_get_file ("ACISCONTAM")))
      return -1;
 
-   if (-1 == read_contam_file_for_ccd (file, ccd->ccd_id))
+   if (-1 == read_contam_file_for_ccd (file, ccd->ccd_id, verbose))
      {
 	marx_free (file);
 	return -1;

--- a/marx/libsrc/caldb.c
+++ b/marx/libsrc/caldb.c
@@ -501,7 +501,7 @@ static int ext_acis_qe_fun (void *vccdid, JDFits_Type *ft)
    return 0;
 }
 
-int _marx_read_acis_qe (int ccdid, float **enp, float **qep, unsigned int *np)
+int _marx_read_acis_qe (int ccdid, float **enp, float **qep, unsigned int *np, int verbose)
 {
    JDFits_Type *ft;
    JDFits_Row_Type *r;
@@ -516,7 +516,7 @@ int _marx_read_acis_qe (int ccdid, float **enp, float **qep, unsigned int *np)
    if (NULL == (file = _marx_caldb_get_file ("ACISQE")))
      return -1;
 
-   marx_message ("\t%s for [CCDID = %d]\n", file, ccdid);
+   if (verbose > 1) marx_message ("\t%s for [CCDID = %d]\n", file, ccdid);
    ft = jdfits_find_binary_table (file, ext_acis_qe_fun, (void *)&ccdid);
    if (ft == NULL)
      {

--- a/marx/libsrc/detector.c
+++ b/marx/libsrc/detector.c
@@ -41,6 +41,8 @@ _Marx_Coord_Transform_Type _Marx_Det_XForm_Matrix;
 int _Marx_Det_Ideal_Flag;
 int _Marx_Det_Extend_Flag;
 
+static int verbose = 0;
+
 static Param_Table_Type Det_Parm_Table [] =
 {
    {"DetOffsetX",	PF_REAL_TYPE,		&_Marx_Det_XForm_Matrix.dx},
@@ -374,7 +376,7 @@ int marx_detect (Marx_Photon_Type *pt, int verbose) /*{{{*/
 
    if (Detector->detect != NULL)
      {
-	if (verbose)
+	if (verbose > 0)
 	  {
 	     marx_message ("Detecting with %s\n", Detector->name);
 	  }

--- a/marx/libsrc/detpix.c
+++ b/marx/libsrc/detpix.c
@@ -106,7 +106,7 @@ static Det_Name_Type Detectors [] =
 };
 
 Marx_Detector_Type *
-marx_get_detector_info (char *detname) /*{{{*/
+marx_get_detector_info (char *detname, int verbose) /*{{{*/
 {
    Marx_Detector_Type *d;
    Det_Name_Type *dn;
@@ -134,29 +134,29 @@ marx_get_detector_info (char *detname) /*{{{*/
 	return NULL;
 
       case MARX_DETECTOR_ACIS_S:
-	d = _marx_get_acis_s_detector ();
+	d = _marx_get_acis_s_detector (verbose);
 	break;
 
       case MARX_DETECTOR_ACIS_I:
-	d = _marx_get_acis_i_detector ();
+	d = _marx_get_acis_i_detector (verbose);
 	break;
 
       case MARX_DETECTOR_HRC_S:
-	d = _marx_get_hrc_s_detector ();
+	d = _marx_get_hrc_s_detector (verbose);
 	break;
 
       case MARX_DETECTOR_HRC_I:
-	d = _marx_get_hrc_i_detector ();
+	d = _marx_get_hrc_i_detector (verbose);
 	break;
 #if MARX_HAS_IXO_SUPPORT
 # ifdef MARX_DETECTOR_IXO_CATGS_CCD
       case MARX_DETECTOR_IXO_CATGS_CCD:
-	d = _marx_get_ixo_ccd_detector ();
+	d = _marx_get_ixo_ccd_detector (verbose);
 	break;
 # endif
 # ifdef MARX_DETECTOR_IXO_XMS
       case MARX_DETECTOR_IXO_XMS:
-	d = _marx_get_ixo_xms_detector ();
+	d = _marx_get_ixo_xms_detector (verbose);
 	break;
 # endif
 #endif

--- a/marx/libsrc/dither.c
+++ b/marx/libsrc/dither.c
@@ -258,7 +258,7 @@ static void close_aspsol (void)
 }
 
 /** Read the next point in the asol fits file and set variable Aspsol to it.
-  * There is no randomn access, this will always read exactly the next line
+  * There is no random access, this will always read exactly the next line
   * in the fits file.
   * Aspsol is a module level variable that is defined when the FILE dither
   * model is in use.
@@ -279,6 +279,7 @@ static int get_single_aspsol_point (void)
    if (-1 == jdfits_simple_d_read_btable (Aspsol.bt, buf))
      {
 	close_aspsol ();
+  marx_message("Simulation stopped early because end of ASPSOL file was reached at time %f.\n", Aspsol.t1);
 	return -1;
      }
 

--- a/marx/libsrc/eamirror.c
+++ b/marx/libsrc/eamirror.c
@@ -129,6 +129,7 @@ int _marx_ea_mirror_init (Param_File_Type *p) /*{{{*/
    unsigned int i, j;
    unsigned int n_mirrors = MARX_NUM_MIRRORS;
    char *file;
+   int verbose;
 
    if ((-1 == pf_get_parameters (p, HRMA_Parm_Table))
        || (HRMA_EA_File == NULL) || (0 == *HRMA_EA_File))
@@ -160,7 +161,10 @@ int _marx_ea_mirror_init (Param_File_Type *p) /*{{{*/
    if (Mirrors.energies != NULL) JDMfree_float_vector (Mirrors.energies);
    Mirrors.energies = NULL;
 
-   marx_message ("Reading binary mirror effective area file\n\t%s\n", file);
+   if (-1 == pf_get_integer(p, "Verbose", &verbose))
+     return -1;
+
+   if (verbose > 1) marx_message ("Reading binary mirror effective area file\n\t%s\n", file);
 
    if (-1 == marx_f_read_bdat (file, &nread, 7,
 			       NULL,   /* wavelength */

--- a/marx/libsrc/grating.c
+++ b/marx/libsrc/grating.c
@@ -106,19 +106,19 @@ int marx_grating_diffract (Marx_Photon_Type *pt, int verbose) /*{{{*/
    switch (Grating)
      {
       case MARX_GRATING_LETG:
-	if (verbose) marx_message ("Diffracting from LETG.\n");
+	if (verbose > 0) marx_message ("Diffracting from LETG.\n");
 	status = _marx_letg_diffract (pt);
 	break;
 
       case MARX_GRATING_HETG:
-	if (verbose) marx_message ("Diffracting from HETG.\n");
+	if (verbose > 0) marx_message ("Diffracting from HETG.\n");
 	status = _marx_hetg_diffract (pt);
 	break;
 
 #if MARX_HAS_IXO_SUPPORT
 # ifdef MARX_GRATING_CATGS
       case MARX_GRATING_CATGS:
-	if (verbose) marx_message ("Diffracting from CATGS.\n");
+	if (verbose > 0) marx_message ("Diffracting from CATGS.\n");
 	status = _marx_catgs_diffract (pt);
 	break;
 # endif

--- a/marx/libsrc/hrc-i.c
+++ b/marx/libsrc/hrc-i.c
@@ -46,6 +46,8 @@ static _Marx_HRC_QE_Type Filter_QEs [NUM_FILTER_REGIONS];
 static Marx_HRC_Blur_Parm_Type *HRC_I_Blur_Parms;
 static Marx_Detector_Geometry_Type *HRC_I_MCP;
 
+static int verbose = 0;
+
 static Param_Table_Type Parm_Table [] =
 {
    {"HRC-I-QEFile",	PF_FILE_TYPE,		&MCP_QEs[0].file},
@@ -184,8 +186,7 @@ _marx_hrc_i_detect (Marx_Photon_Type *pt) /*{{{*/
 
 /*}}}*/
 
-int
-_marx_hrc_i_init (Param_File_Type *p) /*{{{*/
+int _marx_hrc_i_init(Param_File_Type *p) /*{{{*/
 {
    unsigned int i;
    Marx_Detector_Type *hrc;
@@ -200,7 +201,10 @@ _marx_hrc_i_init (Param_File_Type *p) /*{{{*/
    if (-1 == read_hrc_i_blur_parms (p))
      return -1;
 
-   if (NULL == (hrc = marx_get_detector_info ("HRC-I")))
+   if (-1 == pf_get_integer(p, "Verbose", &verbose))
+     return -1;
+
+   if (NULL == (hrc = marx_get_detector_info ("HRC-I", verbose)))
      return -1;
 
    HRC_I_MCP = hrc->facet_list;
@@ -209,13 +213,13 @@ _marx_hrc_i_init (Param_File_Type *p) /*{{{*/
 
    for (i = 0; i < _MARX_NUM_HRC_I_CHIPS; i++)
      {
-	if (-1 == _marx_hrc_read_efficiencies (MCP_QEs + i))
+	if (-1 == _marx_hrc_read_efficiencies (MCP_QEs + i, verbose))
 	  return -1;
      }
 
    for (i = 0; i < NUM_FILTER_REGIONS; i++)
      {
-	if (-1 == _marx_hrc_read_efficiencies (Filter_QEs + i))
+	if (-1 == _marx_hrc_read_efficiencies (Filter_QEs + i, verbose))
 	  return -1;
      }
 

--- a/marx/libsrc/hrc_i_geom.c
+++ b/marx/libsrc/hrc_i_geom.c
@@ -46,6 +46,8 @@ static JDMVector_Type UL_Vector;
 static JDMVector_Type UR_Vector;
 static double LL_CXCY[2];
 
+static int verbose = 0;
+
 static int setup_coordinate_xforms (void)
 {
    double len;
@@ -191,7 +193,10 @@ int _marx_hrc_i_geom_init (Param_File_Type *pf)
    if (NULL == (file = marx_make_data_file_name (file)))
      return -1;
 
-   marx_message ("\t%s\n", file);
+   if (-1 == pf_get_integer(pf, "Verbose", &verbose))
+     return -1;
+
+   if (verbose > 1) marx_message ("\t%s\n", file);
 
    if (-1 == _marx_read_simple_data_file (file, Array_Data_Table))
      {
@@ -246,7 +251,7 @@ static int print_info (Marx_Detector_Type *det, FILE *fp)
    return 0;
 }
 
-Marx_Detector_Type *_marx_get_hrc_i_detector (void)
+Marx_Detector_Type *_marx_get_hrc_i_detector (int verbose)
 {
    Marx_Detector_Type *d;
    Marx_Detector_Geometry_Type *g;

--- a/marx/libsrc/hrc_s_geom.c
+++ b/marx/libsrc/hrc_s_geom.c
@@ -530,7 +530,7 @@ static int print_info (Marx_Detector_Type *det, FILE *fp)
    return 0;
 }
 
-Marx_Detector_Type *_marx_get_hrc_s_detector (void)
+Marx_Detector_Type *_marx_get_hrc_s_detector (int verbose)
 {
    int id;
    Marx_Detector_Type *d;

--- a/marx/libsrc/ixocatgs.c
+++ b/marx/libsrc/ixocatgs.c
@@ -600,7 +600,7 @@ static double Support_Period = 5.0;    /* microns */
 #define MAX_GEFF_ORDER 16
 #define MAX_GEFF_COLUMNS (MAX_GEFF_ORDER-MIN_GEFF_ORDER+2)
 
-static Grating_Eff_Type *read_geff_caldb_file (char *file)
+static Grating_Eff_Type *read_geff_caldb_file (char *file, int verbose)
 {
    int order, min_order, max_order;
    unsigned int num_energies, num_orders = 0;
@@ -614,7 +614,7 @@ static Grating_Eff_Type *read_geff_caldb_file (char *file)
 
    Grating_Eff_Type *geff = NULL;
    sprintf (hduname, "IXO_GREFF");
-   marx_message ("\t%s[%s]\n", file, hduname);
+   if (verbose > 1) marx_message ("\t%s[%s]\n", file, hduname);
 
    if (NULL == (f = _marx_open_binary_hdu (file, hduname)))
      return NULL;
@@ -715,14 +715,14 @@ return_error:
    return NULL;
 }
 
-static Grating_Eff_Type *read_geff_file (char *file)
+static Grating_Eff_Type *read_geff_file (char *file, int verbose)
 {
    Grating_Eff_Type *geff;
 
    if (NULL == (file = marx_make_data_file_name (file)))
      return NULL;
 
-   geff = read_geff_caldb_file (file);
+   geff = read_geff_caldb_file (file, verbose);
    marx_free (file);
    return geff;
 }
@@ -1212,6 +1212,7 @@ int _marx_catgs_init (Param_File_Type *pf)
 {
    Grating_Eff_Type *left_geff, *right_geff;
    int ret;
+   int verbose;
 
    CatGS_Init_Called++;
 
@@ -1220,9 +1221,12 @@ int _marx_catgs_init (Param_File_Type *pf)
    if (-1 == read_ixo_catgs_parms (pf))
      return -1;
 
-   if (NULL == (left_geff = read_geff_file (Left_Grating_Eff_File)))
+   if (-1 == pf_get_integer(pf, "Verbose", &verbose))
      return -1;
-   if (NULL == (right_geff = read_geff_file (Right_Grating_Eff_File)))
+
+   if (NULL == (left_geff = read_geff_file (Left_Grating_Eff_File, verbose)))
+     return -1;
+   if (NULL == (right_geff = read_geff_file (Right_Grating_Eff_File, verbose)))
      {
 	free_grating_eff_type (left_geff);
 	return -1;

--- a/marx/libsrc/ixoccd.c
+++ b/marx/libsrc/ixoccd.c
@@ -34,6 +34,8 @@ static double CCD_Gain = 3.65*0.001;   /* keV/electron */
 static double Fano_Factor = 0.12;
 static double Read_Noise = 4;			       /* electrons */
 
+static int verbose = 0;
+
 struct _IXO_CCD_QE_Type
 {
    unsigned int num_refs;
@@ -432,7 +434,7 @@ static int read_ixo_ccd_parms (Param_File_Type *p)
 }
 
 static Marx_Detector_Type IXO_CCD_Detector;
-Marx_Detector_Type *_marx_get_ixo_ccd_detector (void)
+Marx_Detector_Type *_marx_get_ixo_ccd_detector (int verbose)
 {
    Marx_Detector_Type *d;
 
@@ -457,6 +459,9 @@ int _marx_ixoccd_init (Param_File_Type *p)
    Marx_Detector_Type *d;
    Marx_Detector_Geometry_Type *g;
 
+   if (-1 == pf_get_integer(p, "Verbose", &verbose))
+     return -1;
+
    if ((0 == CatGS_Init_Called)
        && (-1 == _marx_catgs_init (p)))/* need this initialized */
      return -1;
@@ -464,7 +469,7 @@ int _marx_ixoccd_init (Param_File_Type *p)
    if (-1 == read_ixo_ccd_parms (p))
      return -1;
 
-   if (NULL == (d = _marx_get_ixo_ccd_detector ()))
+   if (NULL == (d = _marx_get_ixo_ccd_detector (verbose)))
      return -1;
 
    qeinfo = NULL;
@@ -478,7 +483,7 @@ int _marx_ixoccd_init (Param_File_Type *p)
 	if (NULL == (file = marx_make_data_file_name (QE_CCD_File)))
 	  return -1;
 
-	marx_message ("\t%s\n", file);
+	if (verbose > 1) marx_message ("\t%s\n", file);
 	qeinfo = read_ccd_qe_file (file);
 	marx_free (file);
 

--- a/marx/libsrc/ixomirror.c
+++ b/marx/libsrc/ixomirror.c
@@ -462,7 +462,7 @@ static void free_optical_constants (void)
    Num_Energies = 0;
 }
 
-static int read_opt_constants (void)
+static int read_opt_constants (int verbose)
 {
    unsigned int nread;
    char *file;
@@ -479,7 +479,7 @@ static int read_opt_constants (void)
    /* The optical constant file consists of:
     *   energy (KeV), beta, delta
     */
-   marx_message ("Reading binary HRMA optical constants:\n\t%s\n", file);
+   if (verbose > 1) marx_message ("Reading binary HRMA optical constants:\n\t%s\n", file);
 
    if (-1 == marx_f_read_bdat (file, &nread, 3, &Energies, &Betas, &Deltas))
      {
@@ -826,6 +826,7 @@ return_error:
 int _marx_ixo_mirror_init (Param_File_Type *p) /*{{{*/
 {
    char *file;
+   int verbose;
 
    if (-1 == pf_get_parameters (p, IXOMirror_Parm_Table))
      return -1;
@@ -874,7 +875,7 @@ int _marx_ixo_mirror_init (Param_File_Type *p) /*{{{*/
 
    if (Mirror_Is_Ideal == 0)
      {
-	if (-1 == read_opt_constants ())
+	if (-1 == read_opt_constants (verbose))
 	  return -1;
      }
 

--- a/marx/libsrc/ixoxms.c
+++ b/marx/libsrc/ixoxms.c
@@ -243,7 +243,7 @@ static Marx_Detector_Geometry_Type *setup_geom (void)
 
 static Marx_Detector_Type IXO_XMS_Detector;
 
-Marx_Detector_Type *_marx_get_ixo_xms_detector (void)
+Marx_Detector_Type *_marx_get_ixo_xms_detector (int verbose)
 {
    Marx_Detector_Type *d;
    Marx_Detector_Geometry_Type *g;
@@ -276,11 +276,15 @@ int _marx_ixoxms_init (Param_File_Type *pf)
    Marx_QE_Type *qeinfo;
    Marx_Detector_Type *d;
    Marx_Detector_Geometry_Type *xms;
+   int verbose;
 
    if (-1 == read_ixo_ccd_parms (pf))
      return -1;
 
-   if (NULL == (d = _marx_get_ixo_xms_detector ()))
+   if (-1 == pf_get_integer(pf, "Verbose", &verbose))
+     return -1;
+
+   if (NULL == (d = _marx_get_ixo_xms_detector (verbose)))
      return -1;
 
    qeinfo = NULL;

--- a/marx/libsrc/marx.h
+++ b/marx/libsrc/marx.h
@@ -459,7 +459,7 @@ typedef struct _Marx_Detector_Type
 }
 Marx_Detector_Type;
 
-extern Marx_Detector_Type *marx_get_detector_info (char *);
+extern Marx_Detector_Type *marx_get_detector_info (char *, int);
 extern int marx_compute_tiled_pixel (Marx_Detector_Type *,
 				     int, unsigned int, unsigned int,
 				     unsigned int *, unsigned int *);

--- a/marx/libsrc/mblur.c
+++ b/marx/libsrc/mblur.c
@@ -43,6 +43,7 @@
 #include "_marx.h"
 
 static int Perform_Blur = 0;
+static int verbose = 0;
 
 /* This structure defines theta vs photon energy and encircled energy */
 typedef struct /*{{{*/
@@ -106,12 +107,17 @@ int _marx_init_mirror_blur (Param_File_Type *p) /*{{{*/
 	return -1;
      }
 
-   if (NULL == (file = marx_make_data_file_name (filebuf)))
-     return -1;
+     if (-1 == pf_get_integer(p, "Verbose", &verbose))
+       return -1;
 
-   marx_message ("Reading blur data file:\n\t%s\n", file);
+     if (NULL == (file = marx_make_data_file_name(filebuf)))
+       return -1;
+     if (verbose == 1)
+       marx_message("Reading blur data file");
+     if (verbose > 1)
+       marx_message("Reading blur data file:\n\t%s\n", file);
 
-   if (NULL == (fp = fopen (file, "rb")))
+     if (NULL == (fp = fopen(file, "rb")))
      {
 	marx_error ("Unable to open file: %s", file);
 	marx_free (file);

--- a/marx/libsrc/mirror.c
+++ b/marx/libsrc/mirror.c
@@ -43,6 +43,7 @@
 double Marx_Mirror_Geometric_Area = 1.0;
 
 static int Mirror = -1;
+static int verbose = 0;
 
 int marx_mirror_init (Param_File_Type *pf) /*{{{*/
 {
@@ -50,6 +51,9 @@ int marx_mirror_init (Param_File_Type *pf) /*{{{*/
    char buf[PF_MAX_LINE_LEN];
 
    if (-1 == pf_get_string (pf, "MirrorType", buf, sizeof (buf)))
+     return -1;
+
+   if (-1 == pf_get_integer(pf, "Verbose", &verbose))
      return -1;
 
    if (!strcmp (buf, "HRMA"))
@@ -112,15 +116,15 @@ int marx_mirror_reflect (Marx_Photon_Type *p, int verbose) /*{{{*/
    switch (Mirror)
      {
       case MARX_MIRROR_HRMA:
-	if (verbose) marx_message ("Reflecting from HRMA\n");
+	if (verbose > 0) marx_message ("Reflecting from HRMA\n");
 	return _marx_hrma_mirror_reflect (p);
 
       case MARX_MIRROR_EA:
-	if (verbose) marx_message ("Reflecting from EA-MIRROR\n");
+	if (verbose > 0) marx_message ("Reflecting from EA-MIRROR\n");
 	return _marx_ea_mirror_reflect (p);
 
       case MARX_MIRROR_FFIELD:
-	if (verbose) marx_message ("Flat Fielding Rays\n");
+	if (verbose > 0) marx_message ("Flat Fielding Rays\n");
 	return _marx_ff_mirror_reflect (p);
 #if MARX_HAS_IXO_SUPPORT
 # ifdef MARX_MIRROR_IXO

--- a/marx/libsrc/pixlib.c
+++ b/marx/libsrc/pixlib.c
@@ -98,7 +98,7 @@ marx_allocate_chip_to_mnc (char *name, int id)
    Marx_Chip_To_MNC_Type *chip2mnc;
    Marx_Detector_Geometry_Type *g;
 
-   if (NULL == (det = marx_get_detector_info (name)))
+   if (NULL == (det = marx_get_detector_info (name, 2)))
      return NULL;
 
    g = det->facet_list;

--- a/marx/par/marx.par
+++ b/marx/par/marx.par
@@ -14,7 +14,7 @@ DataDirectory,s,h,"$MARX_DATA_DIR",,,"directory for input data"
 OutputVectors,s,h,"ETXYZ123DxyMPOabcdSrB",,,"output data columns (one or more of ETXYZ123DxyMPOabcd)"
 RandomSeed,i,h,-1,,,"random number seed (-1 means use current time)"
 DumpToRayFile,b,h,no,,,"Output in MARX rayfile format?"
-Verbose,b,a,yes,,,"Verbose mode"
+Verbose,i,a,1,,,"Verbose mode"
 #---------------------------------------------------------------------------
 #
 # Science Instrument set up and control

--- a/marx/src/detinfo.c
+++ b/marx/src/detinfo.c
@@ -96,7 +96,7 @@ int main (int argc, char **argv)
 	name = namebuf;
      }
 
-   if (NULL == (det = marx_get_detector_info (name)))
+   if (NULL == (det = marx_get_detector_info (name, 2)))
      usage ();
 
    fprintf (stdout, " Detector Name: %s\n", name);

--- a/marx/src/marx.c
+++ b/marx/src/marx.c
@@ -242,7 +242,7 @@ static int process_photons (Marx_Photon_Type *pt)
 #if PRINT_STATS_ARRAY
    marx_prune_photons (pt); Stats[0] += pt->num_sorted;
 #endif
-   if (-1 == marx_mirror_reflect (pt, 1))
+   if (-1 == marx_mirror_reflect (pt, Marx_Verbose))
      {
 	marx_error ("Error during reflection from mirror");
 	return -1;
@@ -251,7 +251,7 @@ static int process_photons (Marx_Photon_Type *pt)
 #if PRINT_STATS_ARRAY
    marx_prune_photons (pt); Stats[1] += pt->num_sorted;
 #endif
-   if (-1 == marx_grating_diffract (pt, 1))
+   if (-1 == marx_grating_diffract (pt, Marx_Verbose))
      {
 	marx_error ("Unable to diffract photons.");
 	return -1;
@@ -260,7 +260,7 @@ static int process_photons (Marx_Photon_Type *pt)
 #if PRINT_STATS_ARRAY
    marx_prune_photons (pt); Stats[2] += pt->num_sorted;
 #endif
-   if (-1 == marx_detect (pt, 1))
+   if (-1 == marx_detect (pt, Marx_Verbose))
      {
 	marx_error ("Error during detection.");
 	return -1;
@@ -782,26 +782,25 @@ static int cp_par_file (char *file, char *dir) /*{{{*/
 
 /*}}}*/
 #endif
-static Param_Table_Type Control_Parm_Table [] = /*{{{*/
-{
-     {"NumRays",	PF_INTEGER_TYPE, 	&Num_Rays_Marx_Par},
-     {"dNumRays",	PF_INTEGER_TYPE, 	&Num_Rays_Per_Iteration},
-     {"OutputDir",	PF_FILE_TYPE,	 	&Output_Dir},
-     {"OutputVectors",	PF_STRING_TYPE,	 	&Data_To_Write},
-     {"RandomSeed",	PF_INTEGER_TYPE,	&Random_Seed},
-     {"DataDirectory",	PF_STRING_TYPE,		&Data_Directory},
-     {"DumpToRayFile",	PF_BOOLEAN_TYPE,	&Dump_To_Rayfile},
-     {"RayFile",	PF_STRING_TYPE,		&Rayfile_Name},
-     {"SourceType",	PF_STRING_TYPE,		&Source_Name},
-     {"ExposureTime",	PF_REAL_TYPE,		&Exposure_Time},
-     {"Verbose",	PF_BOOLEAN_TYPE,	&Marx_Verbose},
-     {"FocalLength",	PF_REAL_TYPE,		&Marx_Focal_Length},
-     {"DetOffsetX",	PF_DOUBLE_TYPE,		&DetOffset_X},
-     {"DetOffsetY",	PF_DOUBLE_TYPE,		&DetOffset_Y},
-     {"DetOffsetZ",	PF_DOUBLE_TYPE,		&DetOffset_Z},
+static Param_Table_Type Control_Parm_Table[] = /*{{{*/
+    {
+        {"NumRays", PF_INTEGER_TYPE, &Num_Rays_Marx_Par},
+        {"dNumRays", PF_INTEGER_TYPE, &Num_Rays_Per_Iteration},
+        {"OutputDir", PF_FILE_TYPE, &Output_Dir},
+        {"OutputVectors", PF_STRING_TYPE, &Data_To_Write},
+        {"RandomSeed", PF_INTEGER_TYPE, &Random_Seed},
+        {"DataDirectory", PF_STRING_TYPE, &Data_Directory},
+        {"DumpToRayFile", PF_BOOLEAN_TYPE, &Dump_To_Rayfile},
+        {"RayFile", PF_STRING_TYPE, &Rayfile_Name},
+        {"SourceType", PF_STRING_TYPE, &Source_Name},
+        {"ExposureTime", PF_REAL_TYPE, &Exposure_Time},
+        {"Verbose", PF_INTEGER_TYPE, &Marx_Verbose},
+        {"FocalLength", PF_REAL_TYPE, &Marx_Focal_Length},
+        {"DetOffsetX", PF_DOUBLE_TYPE, &DetOffset_X},
+        {"DetOffsetY", PF_DOUBLE_TYPE, &DetOffset_Y},
+        {"DetOffsetZ", PF_DOUBLE_TYPE, &DetOffset_Z},
 
-     {NULL, 0, NULL}
-};
+        {NULL, 0, NULL}};
 
 /*}}}*/
 
@@ -1046,7 +1045,7 @@ static int write_obs_par (double total_time)
 	detector = "HRC-I";
 	datamode = "IMAGING";
 	if (with_grating) datamode = "SPECTROSCOPIC";
-	d = marx_get_detector_info (detector);
+	d = marx_get_detector_info (detector, 2);
 	break;
 
       case MARX_DETECTOR_HRC_S:
@@ -1054,21 +1053,21 @@ static int write_obs_par (double total_time)
 	detector = "HRC-S";
 	datamode = "IMAGING";
 	if (with_grating) datamode = "SPECTROSCOPIC";
-	d = marx_get_detector_info (detector);
+	d = marx_get_detector_info (detector, 2);
 	break;
 
       case MARX_DETECTOR_ACIS_I:
 	obsdir_file = "obs/acis_i_obs.par";
 	detector = "ACIS-I";
 	datamode = "GRADED";
-	d = marx_get_detector_info (detector);
+	d = marx_get_detector_info (detector, 2);
 	break;
 
       case MARX_DETECTOR_ACIS_S:
 	obsdir_file = "obs/acis_s_obs.par";
 	detector = "ACIS-S";
 	datamode = "GRADED";
-	d = marx_get_detector_info (detector);
+	d = marx_get_detector_info (detector, 2);
 	break;
 
       default:

--- a/marx/src/marx.c
+++ b/marx/src/marx.c
@@ -573,7 +573,7 @@ int main (int argc, char **argv) /*{{{*/
 	     return 1;
 	  }
 
-	marx_message ("\t%d collected.\n", num_collected);
+	marx_message ("\t%d photons collected.\n", num_collected);
 	if (num_collected == 0)
 	  break;
 

--- a/marx/src/marx2fits.c
+++ b/marx/src/marx2fits.c
@@ -2417,7 +2417,7 @@ static int get_marx_pfile_info (void) /*{{{*/
      Simulation_Grating_Type = MARX_GRATING_LETG;
    else Simulation_Grating_Type = 0;
 
-   The_Detector = marx_get_detector_info (DetectorType);
+   The_Detector = marx_get_detector_info (DetectorType, 2);
    if (The_Detector == NULL)
      {
 	pf_close_parameter_file (pf);

--- a/marx/src/marxasp.c
+++ b/marx/src/marxasp.c
@@ -465,7 +465,7 @@ static int get_marx_pfile_info (Param_File_Type *pf)
      Simulation_Grating_Type = 2;
    else Simulation_Grating_Type = 0;
 
-   if (NULL == (dt = marx_get_detector_info (DetectorType)))
+   if (NULL == (dt = marx_get_detector_info (DetectorType, 2)))
      {
 	pf_close_parameter_file (pf);
 	marx_error ("*** DetectorType %s not supported.\n", DetectorType);

--- a/marx/src/sky2chip.c
+++ b/marx/src/sky2chip.c
@@ -59,7 +59,7 @@ int main (int argc, char **argv)
    ra = PI/(180.0 * 60) * ra;
    dec = PI/(180.0 * 60) * dec;
 
-   if (NULL == (det = marx_get_detector_info (name)))
+   if (NULL == (det = marx_get_detector_info (name, 2)))
      usage ();
 
    mnc.x = -cos (dec) * cos (ra);

--- a/marxrsp/marxrsp.c
+++ b/marxrsp/marxrsp.c
@@ -240,7 +240,7 @@ static int check_simulation_parameters (void)
    pf_close_parameter_file (pf);
 
    if ((0 != strncmp (buf, "ACIS", 4))
-       || (NULL == (det = marx_get_detector_info (buf))))
+       || (NULL == (det = marx_get_detector_info (buf, 2))))
      {
 	fprintf (stderr, "DetectorType %s not supported by this program\n",
 		 buf);


### PR DESCRIPTION
These are two almost unrelated changes, one per commit:
1) Add a warning when a simulation ends because it reaches the end of the ASPSOL file.
2) In order to see that warning, make `Verbosity` an integer for more fine-grained control. 