### PR TITLE
Improve error message in marxasp

### DIFF
--- a/marx/src/marxasp.c
+++ b/marx/src/marxasp.c
@@ -417,6 +417,15 @@ static int get_marx_pfile_info (Param_File_Type *pf)
    if (-1 == pf_get_parameters (pf, Parm_Table))
      return -1;
 
+   if (0 == strcmp(Dither_Model, "FILE"))
+   {
+     marx_error("\
+*** This simulation used an input FILE for dither.\n\
+    There is no need to run marxasp to generate a new ASPSOL file.\n\
+    Instead, use the dither file that was used in the marx simulation for the analysis.\n");
+   return -1;
+   }
+
    if (0 == strcmp (Dither_Model, "INTERNAL"))
      used_dither = 1;
    else
@@ -424,8 +433,7 @@ static int get_marx_pfile_info (Param_File_Type *pf)
 	if (0 != strcmp (Dither_Model, "NONE"))
 	  {
 	     marx_error ("\
-*** This simulation did not use the INTERNAL dither model.  Re-run the\n\
-    simulation with DitherModel=INTERNAL.\n");
+*** Unknown dither model %s\n", Dither_Model);
 	     return -1;
 	  }
      }


### PR DESCRIPTION
Previously, marxasp issues an error prompting the user to re-run the simulation
with DitherModel=INTERNAL, when run a simulation that used an ASPSOL input file.
 However, that's not what the typical user wants:
If the simulation was run with a real ASPSOL file, then that file should be used.
It's still true that marxasp should issue an error (since it won't generate anything),
but the message is more helpful now.

fixes #53