### PR TITLE
Fix issues with rayfiles

### DIFF
--- a/marx/libsrc/dither.c
+++ b/marx/libsrc/dither.c
@@ -181,6 +181,25 @@ static int get_internal_dither (double t, Marx_Dither_Type *d,
    return 1;
 }
 
+/* Record the dither state but do not actually dither the rays, which are
+ * already assumed to be dithered a;ready in the input file.
+ */
+static int get_internal_dither_record_only(double t, Marx_Dither_Type *d,
+                                         double *rap, double *decp, double *rollp)
+{
+  int status;
+
+  if (1 != (status = get_internal_dither(t, d, rap, decp, rollp)))
+    return status;
+
+  *rap = 0;
+  *decp = 0;
+  *rollp = 0;
+
+  return 1;
+}
+
+
 static int get_zeroamp_internal_dither (double t, Marx_Dither_Type *d,
 					double *rap, double *decp, double *rollp)
 {
@@ -209,7 +228,10 @@ static int init_internal_dither (int dither_flag)
 	Ra_Amp = Ra_Amp * (PI/(180.0 * 3600));
 	Dec_Amp = Dec_Amp * (PI/(180.0 * 3600));
 	Roll_Amp = Roll_Amp * (PI/(180.0 * 3600));
-	Get_Dither_Function = get_internal_dither;
+  if (dither_flag & _MARX_DITHER_RECORD_ONLY)
+    Get_Dither_Function = get_internal_dither_record_only;
+  else
+    Get_Dither_Function = get_internal_dither;
 	marx_message ("[Using INTERNAL dither model]\n");
      }
    Get_Dither_Par_Means = get_dither_par_means_0;

--- a/marx/libsrc/s-rayfile.c
+++ b/marx/libsrc/s-rayfile.c
@@ -97,11 +97,6 @@ int marx_dump_rayfile (char *file) /*{{{*/
 	fprintf (stdout, "%d\t%u\t%d\t%d",
 		 at.order, at.mirror_shell, at.ccd_num, at.detector_region);
 
-#if MARX_HAS_DITHER
-  fprintf(stdout, "%f\t%f\t%f\t", at.dither_state.ra, at.dither_state.dec, at.dither_state.roll);
-  fprintf(stdout, "%f\t%f\t%f\t", at.dither_state.dy, at.dither_state.dz, at.dither_state.dtheta);
-#endif
-
   putc ('\n', stdout);
      }
 

--- a/marx/libsrc/s-rayfile.c
+++ b/marx/libsrc/s-rayfile.c
@@ -81,7 +81,10 @@ int marx_dump_rayfile (char *file) /*{{{*/
    fprintf (stdout, "\t\tPX\t\tPY\t\tPZ");
    fprintf (stdout, "\tY-Pixel\tZ-Pixel");
    fprintf (stdout, "\tOrder\tMirrorShell\tCCD_Num\tHRC_Region");
-
+#if MARX_HAS_DITHER
+    fprintf(stdout, "\tRA\tDEC\tROLL");
+    fprintf(stdout, "\tDY\tDZ\tDTHETA");
+#endif
    putc ('\n', stdout);
 
    while (1 == fread (&at, sizeof (Marx_Photon_Attr_Type), 1, fp))
@@ -94,7 +97,12 @@ int marx_dump_rayfile (char *file) /*{{{*/
 	fprintf (stdout, "%d\t%u\t%d\t%d",
 		 at.order, at.mirror_shell, at.ccd_num, at.detector_region);
 
-	putc ('\n', stdout);
+#if MARX_HAS_DITHER
+  fprintf(stdout, "%f\t%f\t%f\t", at.dither_state.ra, at.dither_state.dec, at.dither_state.roll);
+  fprintf(stdout, "%f\t%f\t%f\t", at.dither_state.dy, at.dither_state.dz, at.dither_state.dtheta);
+#endif
+
+  putc ('\n', stdout);
      }
 
    fclose (fp);

--- a/marx/libsrc/source.def
+++ b/marx/libsrc/source.def
@@ -51,7 +51,7 @@ static Source_Object_Type Sources [] =
    {"GAUSS", marx_select_gauss_source, 0, 0},
    {"LINE", marx_select_line_source, 0, 0},
    {"BETA", marx_select_beta_source, 0, 0},
-   {"RAYFILE", marx_select_rayfile_source, _MARX_DITHER_UNSUPPORTED, 0},
+   {"RAYFILE", marx_select_rayfile_source, _MARX_DITHER_RECORD_ONLY, 0},
    {"DISK", marx_select_disk_source, 0, 0},
    {"USER", marx_select_user_source, 0, 0},
    {"SAOSAC", marx_select_saosac_source, _MARX_DITHER_ZERO_AMP|_MARX_DITHER_RECORD_ONLY, 0},

--- a/marx/src/marx.c
+++ b/marx/src/marx.c
@@ -579,31 +579,33 @@ int main (int argc, char **argv) /*{{{*/
 
 	total_num_collected += num_collected;
 
-	if (-1 == process_photons (pt))
-	  goto return_error;
+  if (!Dump_To_Rayfile)
+  {
+    if (-1 == process_photons(pt))
+      goto return_error;
+  }
+    if (-1 == (*write_function)(pt, num_collected, open_mode, write_mask, total_time, pt->total_time))
+      goto return_error;
 
-	if (-1 == (*write_function) (pt, num_collected, open_mode, write_mask, total_time, pt->total_time))
-	  goto return_error;
+    open_mode = 0;
+    marx_message("\n");
 
-	open_mode = 0;
-	marx_message ("\n");
+    marx_prune_photons(pt);
+    total_num_detected += pt->num_sorted;
+    total_time += pt->total_time;
 
-	marx_prune_photons (pt);
-	total_num_detected += pt->num_sorted;
-	total_time += pt->total_time;
+    marx_message("Total photons: %lu, Total Photons detected: %lu, (efficiency: %f)\n",
+                 total_num_collected, total_num_detected, (double)total_num_detected / total_num_collected);
 
- 	marx_message ("Total photons: %lu, Total Photons detected: %lu, (efficiency: %f)\n",
-		      total_num_collected, total_num_detected, (double)total_num_detected / total_num_collected);
+    marx_message("  (efficiency this iteration  %f)  Total time: %f\n",
+                 (double)pt->num_sorted / num_collected,
+                 total_time);
 
- 	marx_message ("  (efficiency this iteration  %f)  Total time: %f\n",
-		      (double)pt->num_sorted / num_collected,
-		      total_time);
+    marx_message("\n");
 
-	marx_message ("\n");
-
-	if ((unsigned long)Num_Rays_Per_Iteration != num_collected)
-	  break;
-     }
+    if ((unsigned long)Num_Rays_Per_Iteration != num_collected)
+      break;
+  }
 
    /* drop */
    status = 0;


### PR DESCRIPTION
- add information on dither state to `--raydump` option
- Do not run through HRMA, grating, and detector when dumpting to ray files

Still to be fixed before this can be merged:
source RAYFILE does not write `sky_ra.dat` and other Dither related files to disk and thus `marx2fits` won't work. Need to find out why that's not written.

Technically the issue listed in #30 is already fixed, but until the last piece is addressed, there is no use for this, so don't merge now!

