### PR TITLE
Fix marx2fits with HRC-I

### DIFF
--- a/marx/libsrc/hrc_i_geom.c
+++ b/marx/libsrc/hrc_i_geom.c
@@ -193,10 +193,10 @@ int _marx_hrc_i_geom_init (Param_File_Type *pf)
    if (NULL == (file = marx_make_data_file_name (file)))
      return -1;
 
-   if (-1 == pf_get_integer(pf, "Verbose", &verbose))
-     return -1;
-
-   if (verbose > 1) marx_message ("\t%s\n", file);
+   // when called from e.g. marx2fits, pf may be NULL
+   // and thus no verbose parameter is available
+   if (-1 != pf_get_integer(pf, "Verbose", &verbose))
+     if (verbose > 1) marx_message ("\t%s\n", file);
 
    if (-1 == _marx_read_simple_data_file (file, Array_Data_Table))
      {


### PR DESCRIPTION
Before this fix, marx2fits fails with
`*** DetectorType HRC-I not supported.`. That's because when initializing the detector, it tries to read the paraemter file for the Verbose setting. In the context of marx2fits, that parameter file is NULL, which means that the parameter is not availble.
HRC-S and ACIS are not effected, since they follow a different code path.