### PR TITLE
Fix image flipping

### DIFF
--- a/marx/libsrc/source.c
+++ b/marx/libsrc/source.c
@@ -157,11 +157,10 @@ static int select_source (Marx_Source_Type *st, Param_File_Type *pf, char *name)
    p = JDMv_spherical_to_vector (1.0, 0.5*PI-zoff, yoff);
 
    // SIMPUT gives absolute RA, DEC
-   // IMAGE is always relative to nominal pointing
    // RAYFILE has already put photons in the marx coordinate system
    // SAOSAC has already run photons through the mirrors
    // other MARX sources give relative to source position
-   if (!((strcmp(name, "SIMPUT") == 0) || (strcmp(name, "IMAGE") == 0) ||
+   if (!((strcmp(name, "SIMPUT") == 0) ||
         (strcmp(name, "RAYFILE") == 0) || (strcmp(name, "SAOSAC") == 0))) {
      /* Now add offsets via the proper rotations */
      p = JDMv_rotate_unit_vector (p, JDMv_vector (0, -1, 0), Source_Elevation);


### PR DESCRIPTION
This was introduced in 2292801b5252abe09d7c4e8423c6a397379d8dcf which was written presuming that IAMGE source don't make use of the SourceRa/Dec setting. That is wrong - image source put the center of the image onto those coordinates.